### PR TITLE
feat: add swagger ui

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/SwaggerConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/SwaggerConfig.kt
@@ -1,0 +1,22 @@
+package siksha.wafflestudio.api.common
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    @Bean
+    fun openApi(): OpenAPI {
+        return OpenAPI()
+            .info(configurationInfo())
+    }
+
+    private fun configurationInfo(): Info {
+        return Info()
+            .title("Siksha Spring")
+            .version("v1.0.0")
+            .description("식샤 스프링 API Docs")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ allprojects {
         implementation("io.jsonwebtoken:jjwt-api:0.12.6")
         implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
         implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
+        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
     }
 
     kotlin {


### PR DESCRIPTION
## 작업 내용
* swagger ui 설정 추가

## 공유사항
* swagger dependency 추가 및 기본 정보를 설정했습니다.
* 스프링에서 자주 사용되는 swagger는 springfox와 springdoc이 있다고 하는데 springfox는 레거시 코드가 많고 더이상 업데이트가 되지 않는다고 하여 springdoc을 적용했습니다. (참고. [stackoverflow](https://stackoverflow.com/questions/72479827/are-there-any-advantages-of-using-migrating-to-springdoc-openapi-from-springfox))

### To reviewers
* API 생성시 [spring doc demo](https://github.com/springdoc/springdoc-openapi-demos/tree/master)을 참조하여 설명을 다시면 좀 더 예쁜(?) swagger 문서 생성이 가능합니다.