### PR TITLE
fix: get board api auth 필요없게 수정

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
@@ -32,6 +32,7 @@ class AuthInterceptor(
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
+        if (request.method == HttpMethod.GET.name() && request.requestURI == "/community/boards") return true
         if (request.method == HttpMethod.OPTIONS.name()) return true
 
         return runCatching {


### PR DESCRIPTION
기존 python 서버에서는 GET /board가 auth 필요없었는데
spring에는 필요하게 되어 있어 수정