### PR TITLE
fix aws codeartifact 401 error

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,6 +30,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Get and save Auth Token for CodeArtifact
+        id: get-save-codeartifact-auth-token
+        run: |
+          aws codeartifact get-authorization-token --domain wafflestudio --domain-owner 405906814034 --query authorizationToken --region ap-northeast-1 --output text > .codeartifact-auth-token
+
       - name: FOR K8S) Build, tag, and push image to Amazon ECR
         id: build-image-k8s
         env:
@@ -37,7 +42,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           docker build --platform linux/x86_64 -t $ECR_REGISTRY/$ECR_REPOSITORY_K8S:$IMAGE_TAG . \
-                      --build-arg PROFILE="dev"
+                      --build-arg PROFILE="dev" --build-arg CODEARTIFACT_AUTH_TOKEN=$(cat .codeartifact-auth-token)
 
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_K8S:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY_K8S:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@
 FROM --platform=linux/x86_64 openjdk:17-jdk-alpine AS build
 
 WORKDIR /app
+ARG CODEARTIFACT_AUTH_TOKEN
 
 COPY . .
-RUN ./gradlew clean bootJar --no-daemon
+RUN ./gradlew clean bootJar --no-daemon -PcodeArtifactAuthToken=$CODEARTIFACT_AUTH_TOKEN
 
 # launch jar
 FROM --platform=linux/x86_64 openjdk:17-jdk-alpine


### PR DESCRIPTION
```
Could not resolve com.wafflestudio.spring:spring-boot-starter-waffle-secret-manager:1.0.2.
#9 82.40          > Could not get resource 'https://wafflestudio-***.d.codeartifact.ap-northeast-1.amazonaws.com/maven/spring-waffle/com/wafflestudio/spring/spring-boot-starter-waffle-secret-manager/1.0.2/spring-boot-starter-waffle-secret-manager-1.0.2.pom'.
#9 82.40             > Could not GET 'https://wafflestudio-***.d.codeartifact.ap-northeast-1.amazonaws.com/maven/spring-waffle/com/wafflestudio/spring/spring-boot-starter-waffle-secret-manager/1.0.2/spring-boot-starter-waffle-secret-manager-1.0.2.pom'. Received status code 401 from server: Unauthorized
```

https://github.com/wafflestudio/siksha-spring/actions/runs/14558503504/job/40838672541