### PR TITLE
chore: add health check api

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/WebMvcConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/WebMvcConfig.kt
@@ -16,6 +16,7 @@ class WebMvcConfig(
                 "/error",
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
+                "/actuator/health",
             )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ allprojects {
     dependencies {
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         implementation("org.springframework.boot:spring-boot-starter-web")
+        implementation("org.springframework.boot:spring-boot-starter-actuator")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
         testImplementation("io.mockk:mockk:1.12.0")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
waffle-world k8s health check 용입니다
`spring-boot-starter-actuator` 사용하고
endpoint는 `/actuator/health` 입니다.