### PR TITLE
feat: 키워드 리뷰 및 리뷰 좋아요 기능 추가

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
@@ -21,8 +21,19 @@ class AuthInterceptor(
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
-        if (request.method == HttpMethod.GET.name() && request.requestURI == "/community/boards") return true
         if (request.method == HttpMethod.OPTIONS.name()) return true
+
+        if (request.method == HttpMethod.GET.name()) {
+            if (request.requestURI == "/community/boards") return true
+
+            val isPrivate = request.getParameter("is_private")?.toBoolean() ?: false
+            val isReviewsUri = request.requestURI.startsWith("/reviews")
+
+            if (!isPrivate && isReviewsUri) {
+                request.setAttribute("userId", 0)
+                return true
+            }
+        }
 
         // /menus/와 /menus/lo api를 /menus로 통합하기 위한 처리
         val authHeader = request.getHeader(AUTHORIZATION_HEADER_NAME)

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/AuthInterceptor.kt
@@ -28,8 +28,9 @@ class AuthInterceptor(
 
             val isPrivate = request.getParameter("is_private")?.toBoolean() ?: false
             val isReviewsUri = request.requestURI.startsWith("/reviews")
+            val isMyReviewUri = request.requestURI == "/reviews/me"
 
-            if (!isPrivate && isReviewsUri) {
+            if (!isPrivate && isReviewsUri && !isMyReviewUri) {
                 request.setAttribute("userId", 0)
                 return true
             }

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 import siksha.wafflestudio.api.common.userId
 import siksha.wafflestudio.core.domain.main.menu.dto.MenuDetailsDto
 import siksha.wafflestudio.core.domain.main.review.dto.CommentRecommendationResponse
+import siksha.wafflestudio.core.domain.main.review.dto.KeywordScoreDistributionResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewListResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewRequest
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewScoreDistributionResponse
@@ -62,7 +63,7 @@ class ReviewController(
     @ResponseStatus(HttpStatus.OK)
     fun getReviews(
         @RequestParam("menu_id") menuId: Int,
-        @RequestParam("is_private", required = false) isPrivate: Boolean = false,
+        @RequestParam("is_private", required = false) isPrivate: Boolean,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
         request: HttpServletRequest,
@@ -86,8 +87,13 @@ class ReviewController(
         return reviewService.getScoreDistribution(menuId)
     }
 
-    // TODO: /keyword/dist
-    // 각 키워드별 dist 만들기
+    @GetMapping("/keyword/dist")
+    @ResponseStatus(HttpStatus.OK)
+    fun getKeywordScoreDistribution(
+        @RequestParam("menu_id") menuId: Int,
+    ): KeywordScoreDistributionResponse {
+        return reviewService.getKeywordScoreDistribution(menuId)
+    }
 
     @GetMapping("/filter")
     @ResponseStatus(HttpStatus.OK)
@@ -108,7 +114,6 @@ class ReviewController(
     fun getMyReviews(
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") perPage: Int,
-        @RequestParam("is_private", required = false) isPrivate: Boolean = true,
         request: HttpServletRequest,
     ): ReviewListResponse {
         val userId = request.userId

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
@@ -62,10 +62,12 @@ class ReviewController(
     @ResponseStatus(HttpStatus.OK)
     fun getReviews(
         @RequestParam("menu_id") menuId: Int,
+        @RequestParam("is_private", required = false) isPrivate: Boolean = false,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
+        request: HttpServletRequest
     ): ReviewListResponse {
-        return reviewService.getReviews(menuId, page, size)
+        return reviewService.getReviews(request.userId, menuId, page, size)
     }
 
     @GetMapping("/comments/recommendation")
@@ -92,16 +94,19 @@ class ReviewController(
         @RequestParam("etc", required = false) etc: Boolean?,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam("is_private", required = false) isPrivate: Boolean,
+        request: HttpServletRequest,
     ): ReviewListResponse {
-        return reviewService.getFilteredReviews(menuId, comment, etc, page, size)
+        return reviewService.getFilteredReviews(request.userId, menuId, comment, etc, page, size)
     }
 
     @GetMapping("/me")
     @ResponseStatus(HttpStatus.OK)
     fun getMyReviews(
-        request: HttpServletRequest,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") perPage: Int,
+        @RequestParam("is_private", required = false) isPrivate: Boolean = true,
+        request: HttpServletRequest,
     ): ReviewListResponse {
         val userId = request.userId
         return reviewService.getMyReviews(userId, page, perPage)

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
@@ -3,7 +3,9 @@ package siksha.wafflestudio.api.controller
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -104,4 +106,18 @@ class ReviewController(
         val userId = request.userId
         return reviewService.getMyReviews(userId, page, perPage)
     }
+
+    @PostMapping("/{review_id}/like")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun likeReview(
+        @PathVariable("review_id") reviewId: Int,
+        request: HttpServletRequest,
+    ) = reviewService.likeReview(reviewId, request.userId)
+
+    @DeleteMapping("/{review_id}/like")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun unlikeReview(
+        @PathVariable("review_id") reviewId: Int,
+        request: HttpServletRequest,
+    ) = reviewService.unlikeReview(reviewId, request.userId)
 }

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/ReviewController.kt
@@ -65,7 +65,7 @@ class ReviewController(
         @RequestParam("is_private", required = false) isPrivate: Boolean = false,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
-        request: HttpServletRequest
+        request: HttpServletRequest,
     ): ReviewListResponse {
         return reviewService.getReviews(request.userId, menuId, page, size)
     }
@@ -85,6 +85,9 @@ class ReviewController(
     ): ReviewScoreDistributionResponse {
         return reviewService.getScoreDistribution(menuId)
     }
+
+    // TODO: /keyword/dist
+    // 각 키워드별 dist 만들기
 
     @GetMapping("/filter")
     @ResponseStatus(HttpStatus.OK)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/common/exception/MainException.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/common/exception/MainException.kt
@@ -23,3 +23,11 @@ class MenuLikeException : MainException(HttpStatus.INTERNAL_SERVER_ERROR, "메�
 class DuplicatedNicknameException : MainException(HttpStatus.CONFLICT, "중복된 닉네임이 존재합니다.")
 
 class BannedWordException : MainException(HttpStatus.BAD_REQUEST, "사용이 불가능한 단어가 포함되어 있습니다.")
+
+class KeywordMissingException : MainException(HttpStatus.BAD_REQUEST, "작성하지 않은 키워드 리뷰가 존재합니다.")
+
+class ReviewAlreadyExistsException : MainException(HttpStatus.CONFLICT, "이 메뉴에 대한 리뷰가 이미 존재합니다")
+
+class ReviewSaveFailedException : MainException(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰 저장 중에 오류가 발생했습니다.")
+
+class SelfReviewLikeNotAllowedException : MainException(HttpStatus.BAD_REQUEST, "본인의 리뷰에는 좋아요를 누를 수 없습니다.")

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
@@ -10,6 +10,7 @@ import siksha.wafflestudio.core.domain.main.restaurant.data.Restaurant
 import siksha.wafflestudio.core.util.EtcUtils
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 // /menus 요청에 대한 Menu 단위 Dto
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
@@ -49,8 +50,8 @@ data class MenuInListDto
                 likeInfo: MenuLikeSummary?,
             ): MenuInListDto {
                 return MenuInListDto(
-                    createdAt = menu.getCreatedAt(),
-                    updatedAt = menu.getUpdatedAt(),
+                    createdAt = menu.getCreatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
+                    updatedAt = menu.getUpdatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
                     id = menu.getId(),
                     code = menu.getCode(),
                     nameKr = menu.getNameKr(),
@@ -60,7 +61,7 @@ data class MenuInListDto
                     score = menu.getScore(),
                     reviewCnt = menu.getReviewCnt(),
                     likeCnt = likeInfo?.getLikeCnt() ?: 0,
-                    isLiked = likeInfo?.getIsLiked() ?: false,
+                    isLiked = likeInfo?.getIsLiked() == 1,
                 )
             }
         }
@@ -193,8 +194,8 @@ data class MenuDetailsDto
                 likeInfo: MenuLikeSummary?,
             ): MenuDetailsDto {
                 return MenuDetailsDto(
-                    createdAt = menu.getCreatedAt(),
-                    updatedAt = menu.getUpdatedAt(),
+                    createdAt = menu.getCreatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
+                    updatedAt = menu.getUpdatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
                     id = menu.getId(),
                     restaurantId = menu.getRestaurantId(),
                     code = menu.getCode(),
@@ -206,7 +207,7 @@ data class MenuDetailsDto
                     etc = EtcUtils.convertMenuEtc(menu.getEtc()),
                     score = menu.getScore(),
                     reviewCnt = menu.getReviewCnt(),
-                    isLiked = likeInfo?.getIsLiked() ?: false,
+                    isLiked = likeInfo?.getIsLiked() == 1,
                     likeCnt = likeInfo?.getLikeCnt() ?: 0,
                 )
             }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
@@ -1,5 +1,6 @@
 package siksha.wafflestudio.core.domain.main.menu.dto
 
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -22,9 +23,9 @@ interface MenuSummary {
 
     fun getEtc(): String?
 
-    fun getCreatedAt(): OffsetDateTime
+    fun getCreatedAt(): Timestamp
 
-    fun getUpdatedAt(): OffsetDateTime
+    fun getUpdatedAt(): Timestamp
 
     fun getScore(): Double?
 
@@ -44,7 +45,7 @@ interface MenuLikeSummary {
 
     fun getLikeCnt(): Int
 
-    fun getIsLiked(): Boolean
+    fun getIsLiked(): Int
 }
 
 interface MenuLikeCount {

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
@@ -2,7 +2,6 @@ package siksha.wafflestudio.core.domain.main.menu.dto
 
 import java.sql.Timestamp
 import java.time.LocalDate
-import java.time.OffsetDateTime
 
 interface MenuSummary {
     fun getId(): Int

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
@@ -28,7 +28,9 @@ data class KeywordReview(
     @ManyToOne
     @JoinColumns(
         JoinColumn(name = "restaurant_id", referencedColumnName = "restaurant_id"),
-        JoinColumn(name = "menu_code", referencedColumnName = "code")
+        JoinColumn(name = "menu_code", referencedColumnName = "code"),
+        JoinColumn(name = "menu_date", referencedColumnName = "date"),
+        JoinColumn(name = "menu_type", referencedColumnName = "type")
     )
     val menu: Menu,
 )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
@@ -15,22 +15,19 @@ import siksha.wafflestudio.core.domain.main.menu.data.Menu
 data class KeywordReview(
     @Id
     val id: Int = 0,
-
     val taste: Int,
     val price: Int,
     val foodComposition: Int,
-
     @OneToOne
     @MapsId
     @JoinColumn(name = "review_id")
     val review: Review,
-
     @ManyToOne
     @JoinColumns(
         JoinColumn(name = "restaurant_id", referencedColumnName = "restaurant_id"),
         JoinColumn(name = "menu_code", referencedColumnName = "code"),
         JoinColumn(name = "menu_date", referencedColumnName = "date"),
-        JoinColumn(name = "menu_type", referencedColumnName = "type")
+        JoinColumn(name = "menu_type", referencedColumnName = "type"),
     )
     val menu: Menu,
 )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
@@ -1,0 +1,24 @@
+package siksha.wafflestudio.core.domain.main.review.data
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity(name = "keyword_review")
+@Table(name = "keyword_review")
+data class KeywordReview(
+    @Id
+    val id: Int = 0,
+
+    val flavor: Int,
+    val price: Int,
+    val foodComposition: Int,
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "review_id")
+    val review: Review
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/KeywordReview.kt
@@ -3,9 +3,12 @@ package siksha.wafflestudio.core.domain.main.review.data
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinColumns
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.MapsId
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import siksha.wafflestudio.core.domain.main.menu.data.Menu
 
 @Entity(name = "keyword_review")
 @Table(name = "keyword_review")
@@ -13,12 +16,19 @@ data class KeywordReview(
     @Id
     val id: Int = 0,
 
-    val flavor: Int,
+    val taste: Int,
     val price: Int,
     val foodComposition: Int,
 
     @OneToOne
     @MapsId
     @JoinColumn(name = "review_id")
-    val review: Review
+    val review: Review,
+
+    @ManyToOne
+    @JoinColumns(
+        JoinColumn(name = "restaurant_id", referencedColumnName = "restaurant_id"),
+        JoinColumn(name = "menu_code", referencedColumnName = "code")
+    )
+    val menu: Menu,
 )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/ReviewLike.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/ReviewLike.kt
@@ -1,0 +1,45 @@
+package siksha.wafflestudio.core.domain.main.review.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.UpdateTimestamp
+import siksha.wafflestudio.core.domain.user.data.User
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+@Entity(name = "review_like")
+@Table(name = "review_like",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["user_id", "review_id"]),
+    ],
+)
+data class ReviewLike(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val user: User,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val review: Review,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+    @UpdateTimestamp
+    @Column(nullable = false)
+    val updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/ReviewLike.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/data/ReviewLike.kt
@@ -3,10 +3,10 @@ package siksha.wafflestudio.core.domain.main.review.data
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -19,7 +19,8 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 
 @Entity(name = "review_like")
-@Table(name = "review_like",
+@Table(
+    name = "review_like",
     uniqueConstraints = [
         UniqueConstraint(columnNames = ["user_id", "review_id"]),
     ],

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
@@ -1,7 +1,6 @@
 package siksha.wafflestudio.core.domain.main.review.dto
 
 import java.sql.Timestamp
-import java.time.OffsetDateTime
 
 interface ReviewSummary {
     fun getId(): Int
@@ -16,7 +15,7 @@ interface ReviewSummary {
 
     fun getEtc(): String?
 
-    fun getFlavor(): Int?
+    fun getTaste(): Int?
 
     fun getPrice(): Int?
 
@@ -29,4 +28,19 @@ interface ReviewSummary {
     fun getCreatedAt(): Timestamp
 
     fun getUpdatedAt(): Timestamp
+}
+
+interface KeywordReviewSummary {
+
+    fun getTasteKeyword(): Int
+
+    fun getTasteCnt(): Int
+
+    fun getPriceKeyword(): Int
+
+    fun getPriceCnt(): Int
+
+    fun getFoodCompositionKeyword(): Int
+
+    fun getFoodCompositionCnt(): Int
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
@@ -1,0 +1,27 @@
+package siksha.wafflestudio.core.domain.main.review.dto
+
+import java.time.OffsetDateTime
+
+interface ReviewSummary {
+    fun getId(): Int
+
+    fun getMenuId(): Int
+
+    fun getUserId(): Int
+
+    fun getScore(): Int
+
+    fun getComment(): String?
+
+    fun getEtc(): String?
+
+    fun getFlavor(): Int?
+
+    fun getPrice(): Int?
+
+    fun getFoodComposition(): Int?
+
+    fun getCreatedAt(): OffsetDateTime
+
+    fun getUpdatedAt(): OffsetDateTime
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
@@ -31,7 +31,6 @@ interface ReviewSummary {
 }
 
 interface KeywordReviewSummary {
-
     fun getTasteKeyword(): Int
 
     fun getTasteCnt(): Int

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
@@ -1,5 +1,6 @@
 package siksha.wafflestudio.core.domain.main.review.dto
 
+import java.sql.Timestamp
 import java.time.OffsetDateTime
 
 interface ReviewSummary {
@@ -23,9 +24,9 @@ interface ReviewSummary {
 
     fun getLikeCount(): Int
 
-    fun getIsLiked(): Boolean
+    fun getIsLiked(): Int
 
-    fun getCreatedAt(): OffsetDateTime
+    fun getCreatedAt(): Timestamp
 
-    fun getUpdatedAt(): OffsetDateTime
+    fun getUpdatedAt(): Timestamp
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/QueryDtos.kt
@@ -21,6 +21,10 @@ interface ReviewSummary {
 
     fun getFoodComposition(): Int?
 
+    fun getLikeCount(): Int
+
+    fun getIsLiked(): Boolean
+
     fun getCreatedAt(): OffsetDateTime
 
     fun getUpdatedAt(): OffsetDateTime

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewRequestDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewRequestDtos.kt
@@ -12,9 +12,9 @@ data class ReviewRequest(
     @field:Max(5)
     val score: Int,
     val comment: String? = null,
-    val flavor: String? = null,
-    val price: String? = null,
-    val foodComposition: String? = null,
+    val taste: String = "",
+    val price: String = "",
+    val foodComposition: String = "",
 )
 
 data class ReviewWithImagesRequest(
@@ -24,8 +24,8 @@ data class ReviewWithImagesRequest(
     @field:Max(5)
     val score: Int,
     val comment: String? = null,
-    val flavor: String? = null,
-    val price: String? = null,
-    val foodComposition: String? = null,
+    val taste: String = "",
+    val price: String = "",
+    val foodComposition: String = "",
     val images: List<MultipartFile>? = null,
 )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewRequestDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewRequestDtos.kt
@@ -12,6 +12,9 @@ data class ReviewRequest(
     @field:Max(5)
     val score: Int,
     val comment: String? = null,
+    val flavor: String? = null,
+    val price: String? = null,
+    val foodComposition: String? = null,
 )
 
 data class ReviewWithImagesRequest(
@@ -21,5 +24,8 @@ data class ReviewWithImagesRequest(
     @field:Max(5)
     val score: Int,
     val comment: String? = null,
+    val flavor: String? = null,
+    val price: String? = null,
+    val foodComposition: String? = null,
     val images: List<MultipartFile>? = null,
 )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
@@ -18,9 +18,7 @@ data class ReviewResponse(
     val updatedAt: OffsetDateTime,
 ) {
     companion object {
-        fun from(
-            review: ReviewSummary,
-        ): ReviewResponse {
+        fun from(review: ReviewSummary): ReviewResponse {
             return ReviewResponse(
                 id = review.getId(),
                 menuId = review.getMenuId(),
@@ -28,11 +26,12 @@ data class ReviewResponse(
                 score = review.getScore(),
                 comment = review.getComment(),
                 etc = review.getEtc(),
-                keywordReviews = listOf(
-                    KeywordReviewUtil.getTasteKeyword(review.getTaste()),
-                    KeywordReviewUtil.getPriceKeyword(review.getPrice()),
-                    KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
-                ),
+                keywordReviews =
+                    listOf(
+                        KeywordReviewUtil.getTasteKeyword(review.getTaste()),
+                        KeywordReviewUtil.getPriceKeyword(review.getPrice()),
+                        KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
+                    ),
                 likeCount = review.getLikeCount(),
                 isLiked = review.getIsLiked() == 1,
                 createdAt = review.getCreatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
@@ -65,21 +64,22 @@ data class KeywordScoreDistributionResponse(
     val foodCompositionCnt: Int = 0,
 ) {
     companion object {
-        fun from(
-            keywordReviewSummary: KeywordReviewSummary
-        ): KeywordScoreDistributionResponse {
+        fun from(keywordReviewSummary: KeywordReviewSummary): KeywordScoreDistributionResponse {
             return KeywordScoreDistributionResponse(
-                tasteKeyword = KeywordReviewUtil.getTasteKeyword(
-                    keywordReviewSummary.getTasteKeyword()
-                ),
+                tasteKeyword =
+                    KeywordReviewUtil.getTasteKeyword(
+                        keywordReviewSummary.getTasteKeyword(),
+                    ),
                 tasteCnt = keywordReviewSummary.getTasteCnt(),
-                priceKeyword = KeywordReviewUtil.getPriceKeyword(
-                    keywordReviewSummary.getPriceKeyword()
-                ),
+                priceKeyword =
+                    KeywordReviewUtil.getPriceKeyword(
+                        keywordReviewSummary.getPriceKeyword(),
+                    ),
                 priceCnt = keywordReviewSummary.getPriceCnt(),
-                foodCompositionKeyword = KeywordReviewUtil.getFoodCompositionKeyword(
-                    keywordReviewSummary.getFoodCompositionKeyword()
-                ),
+                foodCompositionKeyword =
+                    KeywordReviewUtil.getFoodCompositionKeyword(
+                        keywordReviewSummary.getFoodCompositionKeyword(),
+                    ),
                 foodCompositionCnt = keywordReviewSummary.getFoodCompositionCnt(),
             )
         }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
@@ -29,7 +29,7 @@ data class ReviewResponse(
                 comment = review.getComment(),
                 etc = review.getEtc(),
                 keywordReviews = listOf(
-                    KeywordReviewUtil.getFlavorKeyword(review.getFlavor()),
+                    KeywordReviewUtil.getTasteKeyword(review.getTaste()),
                     KeywordReviewUtil.getPriceKeyword(review.getPrice()),
                     KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
                 ),
@@ -55,3 +55,33 @@ data class CommentRecommendationResponse(
 data class ReviewScoreDistributionResponse(
     val dist: List<Int>,
 )
+
+data class KeywordScoreDistributionResponse(
+    val tasteKeyword: String = "맛",
+    val tasteCnt: Int = 0,
+    val priceKeyword: String = "가격",
+    val priceCnt: Int = 0,
+    val foodCompositionKeyword: String = "음식구성",
+    val foodCompositionCnt: Int = 0,
+) {
+    companion object {
+        fun from(
+            keywordReviewSummary: KeywordReviewSummary
+        ): KeywordScoreDistributionResponse {
+            return KeywordScoreDistributionResponse(
+                tasteKeyword = KeywordReviewUtil.getTasteKeyword(
+                    keywordReviewSummary.getTasteKeyword()
+                ),
+                tasteCnt = keywordReviewSummary.getTasteCnt(),
+                priceKeyword = KeywordReviewUtil.getPriceKeyword(
+                    keywordReviewSummary.getPriceKeyword()
+                ),
+                priceCnt = keywordReviewSummary.getPriceCnt(),
+                foodCompositionKeyword = KeywordReviewUtil.getFoodCompositionKeyword(
+                    keywordReviewSummary.getFoodCompositionKeyword()
+                ),
+                foodCompositionCnt = keywordReviewSummary.getFoodCompositionCnt(),
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
@@ -1,5 +1,6 @@
 package siksha.wafflestudio.core.domain.main.review.dto
 
+import siksha.wafflestudio.core.util.KeywordReviewUtil
 import java.time.OffsetDateTime
 
 data class ReviewResponse(
@@ -9,9 +10,32 @@ data class ReviewResponse(
     val score: Int,
     val comment: String?,
     val etc: String?,
+    val keywordReviews: List<String?>,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,
-)
+) {
+    companion object {
+        fun from(
+            review: ReviewSummary,
+        ): ReviewResponse {
+            return ReviewResponse(
+                id = review.getId(),
+                menuId = review.getMenuId(),
+                userId = review.getUserId(),
+                score = review.getScore(),
+                comment = review.getComment(),
+                etc = review.getEtc(),
+                keywordReviews = listOf(
+                    KeywordReviewUtil.getFlavorKeyword(review.getFlavor()),
+                    KeywordReviewUtil.getPriceKeyword(review.getPrice()),
+                    KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
+                ),
+                createdAt = review.getCreatedAt(),
+                updatedAt = review.getUpdatedAt(),
+            )
+        }
+    }
+}
 
 data class ReviewListResponse(
     val totalCount: Int,

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
@@ -2,6 +2,7 @@ package siksha.wafflestudio.core.domain.main.review.dto
 
 import siksha.wafflestudio.core.util.KeywordReviewUtil
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 data class ReviewResponse(
     val id: Int,
@@ -33,9 +34,9 @@ data class ReviewResponse(
                     KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
                 ),
                 likeCount = review.getLikeCount(),
-                isLiked = review.getIsLiked(),
-                createdAt = review.getCreatedAt(),
-                updatedAt = review.getUpdatedAt(),
+                isLiked = review.getIsLiked() == 1,
+                createdAt = review.getCreatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
+                updatedAt = review.getUpdatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
             )
         }
     }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/dto/ReviewResponseDtos.kt
@@ -11,6 +11,8 @@ data class ReviewResponse(
     val comment: String?,
     val etc: String?,
     val keywordReviews: List<String?>,
+    val likeCount: Int,
+    val isLiked: Boolean,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,
 ) {
@@ -30,6 +32,8 @@ data class ReviewResponse(
                     KeywordReviewUtil.getPriceKeyword(review.getPrice()),
                     KeywordReviewUtil.getFoodCompositionKeyword(review.getFoodComposition()),
                 ),
+                likeCount = review.getLikeCount(),
+                isLiked = review.getIsLiked(),
                 createdAt = review.getCreatedAt(),
                 updatedAt = review.getUpdatedAt(),
             )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
@@ -1,0 +1,9 @@
+package siksha.wafflestudio.core.domain.main.review.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import siksha.wafflestudio.core.domain.main.review.data.KeywordReview
+
+@Repository
+interface KeywordReviewRepository : JpaRepository<KeywordReview, Int> {
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
@@ -48,6 +48,6 @@ interface KeywordReviewRepository : JpaRepository<KeywordReview, Int> {
     )
     fun findScoreCountsByRestaurantIdAndCode(
         @Param("restaurant_id") restaurantId: Int,
-        @Param("code") code: String
-    ): KeywordReviewSummary?;
+        @Param("code") code: String,
+    ): KeywordReviewSummary?
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/KeywordReviewRepository.kt
@@ -1,9 +1,53 @@
 package siksha.wafflestudio.core.domain.main.review.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import siksha.wafflestudio.core.domain.main.review.data.KeywordReview
+import siksha.wafflestudio.core.domain.main.review.dto.KeywordReviewSummary
 
 @Repository
 interface KeywordReviewRepository : JpaRepository<KeywordReview, Int> {
+    @Query(
+        """
+            SELECT
+              taste_stats.taste_keyword,
+              taste_stats.taste_cnt,
+              price_stats.price_keyword,
+              price_stats.price_cnt,
+              food_stats.food_composition_keyword,
+              food_stats.food_composition_cnt
+            FROM
+              (
+                SELECT taste AS taste_keyword, COUNT(*) AS taste_cnt
+                FROM keyword_review
+                WHERE restaurant_id = :restaurant_id AND menu_code = :code
+                GROUP BY taste
+                ORDER BY taste_cnt DESC
+                LIMIT 1
+              ) AS taste_stats,
+              (
+                SELECT price AS price_keyword, COUNT(*) AS price_cnt
+                FROM keyword_review
+                WHERE restaurant_id = :restaurant_id AND menu_code = :code
+                GROUP BY price
+                ORDER BY price_cnt DESC
+                LIMIT 1
+              ) AS price_stats,
+              (
+                SELECT food_composition AS food_composition_keyword, COUNT(*) AS food_composition_cnt
+                FROM keyword_review
+                WHERE restaurant_id = :restaurant_id AND menu_code = :code
+                GROUP BY food_composition
+                ORDER BY food_composition_cnt DESC
+                LIMIT 1
+              ) AS food_stats;
+        """,
+        nativeQuery = true,
+    )
+    fun findScoreCountsByRestaurantIdAndCode(
+        @Param("restaurant_id") restaurantId: Int,
+        @Param("code") code: String
+    ): KeywordReviewSummary?;
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewLikeRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewLikeRepository.kt
@@ -1,0 +1,8 @@
+package siksha.wafflestudio.core.domain.main.review.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.review.data.ReviewLike
+
+interface ReviewLikeRepository: JpaRepository<ReviewLike, Int> {
+    fun deleteByUserIdAndReviewId(userId: Int, reviewId: Int): Int
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewLikeRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewLikeRepository.kt
@@ -3,6 +3,9 @@ package siksha.wafflestudio.core.domain.main.review.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import siksha.wafflestudio.core.domain.main.review.data.ReviewLike
 
-interface ReviewLikeRepository: JpaRepository<ReviewLike, Int> {
-    fun deleteByUserIdAndReviewId(userId: Int, reviewId: Int): Int
+interface ReviewLikeRepository : JpaRepository<ReviewLike, Int> {
+    fun deleteByUserIdAndReviewId(
+        userId: Int,
+        reviewId: Int,
+    ): Int
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
@@ -40,7 +40,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
         )
         ORDER BY r.created_at DESC
     """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun findByMenuIdOrderByCreatedAtDesc(
         @Param("userId") userId: Int,
@@ -58,7 +58,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
                 WHERE restaurant_id = :restaurantId AND code = :code
             )
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun countByMenuId(
         @Param("restaurantId") restaurantId: Int,

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
@@ -14,14 +14,18 @@ interface ReviewRepository : JpaRepository<Review, Int> {
         value = """
         SELECT 
             r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, 
-            kr.flavor, kr.price, kr.foodComposition, 
+            kr.flavor, kr.price, kr.food_composition, 
             IFNULL(rl.like_count, 0) AS like_count,
-            EXISTS (
-                SELECT 1
-                FROM review_likes rl2
-                WHERE rl2.review_id = r.id AND rl2.user_id = :userId
-            ) AS is_liked,
-            r.createdAt, r.updatedAt 
+            CASE 
+                WHEN EXISTS (
+                    SELECT 1 
+                    FROM review_like rl2 
+                    WHERE rl2.review_id = r.id AND rl2.user_id = :userId
+                ) 
+                THEN 1 
+                ELSE 0 
+            END AS is_liked,
+            r.created_at, r.updated_at 
         FROM review r
         LEFT JOIN keyword_review kr ON r.id = kr.review_id
         LEFT JOIN (
@@ -30,7 +34,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
             GROUP BY review_id
         ) rl ON r.id = rl.review_id
         WHERE r.menu_id = :menuId
-        ORDER BY r.createdAt DESC
+        ORDER BY r.created_at DESC
     """,
         nativeQuery = true
     )
@@ -52,14 +56,18 @@ interface ReviewRepository : JpaRepository<Review, Int> {
         value = """
         SELECT 
             r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, 
-            kr.flavor, kr.price, kr.foodComposition, 
+            kr.flavor, kr.price, kr.food_composition, 
             IFNULL(rl.like_count, 0) AS like_count,
-            EXISTS (
-                SELECT 1
-                FROM review_likes rl2
-                WHERE rl2.review_id = r.id AND rl2.user_id = :userId
-            ) AS is_liked,
-            r.createdAt, r.updatedAt 
+            CASE 
+                WHEN EXISTS (
+                    SELECT 1 
+                    FROM review_like rl2 
+                    WHERE rl2.review_id = r.id AND rl2.user_id = :userId
+                ) 
+                THEN 1 
+                ELSE 0 
+            END AS is_liked,
+            r.created_at, r.updated_at 
         FROM review r
         LEFT JOIN keyword_review kr ON r.id = kr.review_id
         LEFT JOIN (
@@ -98,7 +106,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
 
     @Query(
         """
-    SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.foodComposition, r.createdAt, r.updatedAt 
+    SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.food_composition, r.created_at, r.updated_at 
     FROM review r
     Left JOIN keyword_review kr ON r.id = kr.review_id
     WHERE r.menu.id = :menuId AND r.user.id = :userId
@@ -114,14 +122,18 @@ interface ReviewRepository : JpaRepository<Review, Int> {
         value = """
         SELECT 
             r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, 
-            kr.flavor, kr.price, kr.foodComposition, 
+            kr.flavor, kr.price, kr.food_composition, 
             IFNULL(rl.like_count, 0) AS like_count,
-            EXISTS (
-                SELECT 1
-                FROM review_likes rl2
-                WHERE rl2.review_id = r.id AND rl2.user_id = :userId
-            ) AS is_liked,
-            r.createdAt, r.updatedAt 
+            CASE 
+                WHEN EXISTS (
+                    SELECT 1 
+                    FROM review_like rl2 
+                    WHERE rl2.review_id = r.id AND rl2.user_id = :userId
+                ) 
+                THEN 1 
+                ELSE 0 
+            END AS is_liked,
+            r.created_at, r.updated_at 
         FROM review r
         LEFT JOIN keyword_review kr ON r.id = kr.review_id
         LEFT JOIN (

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/repository/ReviewRepository.kt
@@ -6,20 +6,24 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import siksha.wafflestudio.core.domain.main.review.data.Review
+import siksha.wafflestudio.core.domain.main.review.dto.ReviewSummary
 
 @Repository
 interface ReviewRepository : JpaRepository<Review, Int> {
     @Query(
-        """
-        SELECT r FROM review r
-        WHERE r.menu.id = :menuId
+        value = """
+        SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.foodComposition, r.createdAt, r.updatedAt 
+        FROM review r
+        LEFT JOIN keyword_review kr ON r.id = kr.review_id
+        WHERE r.menu_id = :menuId
         ORDER BY r.createdAt DESC
     """,
+        nativeQuery = true
     )
     fun findByMenuIdOrderByCreatedAtDesc(
         menuId: Int,
         pageable: Pageable,
-    ): List<Review>
+    ): List<ReviewSummary>
 
     @Query(
         """
@@ -31,7 +35,9 @@ interface ReviewRepository : JpaRepository<Review, Int> {
 
     @Query(
         value = """
-    SELECT * FROM review r
+    SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.foodComposition, r.createdAt, r.updatedAt 
+    FROM review r
+    LEFT JOIN keyword_review kr ON r.id = kr.review_id
     WHERE r.menu_id = :menuId
     AND (:comment IS NULL OR (:comment = true AND r.comment IS NOT NULL))
     AND (:etc IS NULL OR (:etc = true AND JSON_EXTRACT(r.etc, '$.images') IS NOT NULL))
@@ -43,7 +49,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
         @Param("comment") comment: Boolean?,
         @Param("etc") etc: Boolean?,
         pageable: Pageable,
-    ): List<Review>
+    ): List<ReviewSummary>
 
     @Query(
         value = """
@@ -62,18 +68,23 @@ interface ReviewRepository : JpaRepository<Review, Int> {
 
     @Query(
         """
-    SELECT r FROM review r
+    SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.foodComposition, r.createdAt, r.updatedAt 
+    FROM review r
+    Left JOIN keyword_review kr ON r.id = kr.review_id
     WHERE r.menu.id = :menuId AND r.user.id = :userId
 """,
+        nativeQuery = true,
     )
     fun findByMenuIdAndUserId(
         @Param("menuId") menuId: Int,
         @Param("userId") userId: Int,
-    ): Review?
+    ): ReviewSummary?
 
     @Query(
         value = """
-    SELECT * FROM review
+    SELECT r.id, r.menu_id AS menuId, r.user_id AS userId, r.score, r.comment, r.etc, kr.flavor, kr.price, kr.foodComposition, r.createdAt, r.updatedAt 
+    FROM review r
+    LEFT JOIN keyword_review kr ON r.id = kr.review_id
     WHERE user_id = :userId
     """,
         nativeQuery = true,
@@ -81,7 +92,7 @@ interface ReviewRepository : JpaRepository<Review, Int> {
     fun findByUserId(
         @Param("userId") userId: Int,
         pageable: Pageable,
-    ): List<Review>
+    ): List<ReviewSummary>
 
     @Query(
         value = """

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
@@ -190,12 +190,13 @@ class ReviewService(
     }
 
     fun getReviews(
+        userId: Int,
         menuId: Int,
         page: Int,
         size: Int,
     ): ReviewListResponse {
         val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
-        val reviews = reviewRepository.findByMenuIdOrderByCreatedAtDesc(menuId, pageable)
+        val reviews = reviewRepository.findByMenuIdOrderByCreatedAtDesc(userId, menuId, pageable)
         val totalCount = reviewRepository.countByMenuId(menuId)
         val hasNext = page * size < totalCount
 
@@ -235,6 +236,7 @@ class ReviewService(
     }
 
     fun getFilteredReviews(
+        userId: Int,
         menuId: Int,
         comment: Boolean?,
         etc: Boolean?,
@@ -242,7 +244,7 @@ class ReviewService(
         size: Int,
     ): ReviewListResponse {
         val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
-        val reviews = reviewRepository.findFilteredReviews(menuId, comment, etc, pageable)
+        val reviews = reviewRepository.findFilteredReviews(userId, menuId, comment, etc, pageable)
         val totalCount = reviewRepository.countFilteredReviews(menuId, comment, etc)
         val hasNext = page * size < totalCount
 

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
@@ -6,6 +6,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import siksha.wafflestudio.core.domain.common.exception.CommentNotFoundException
 import siksha.wafflestudio.core.domain.common.exception.InvalidScoreException
 import siksha.wafflestudio.core.domain.common.exception.MenuNotFoundException
@@ -112,23 +113,7 @@ class ReviewService(
                 user.id.toString(),
             )
 
-        return MenuDetailsDto(
-            createdAt = menuSummary.getCreatedAt(),
-            updatedAt = menuSummary.getUpdatedAt(),
-            id = menuSummary.getId(),
-            restaurantId = menuSummary.getRestaurantId(),
-            code = menuSummary.getCode(),
-            date = menuSummary.getDate(),
-            type = menuSummary.getType(),
-            nameKr = menuSummary.getNameKr(),
-            nameEn = menuSummary.getNameEn(),
-            price = menuSummary.getPrice(),
-            etc = EtcUtils.convertMenuEtc(menuSummary.getEtc()),
-            score = menuSummary.getScore(),
-            reviewCnt = menuSummary.getReviewCnt(),
-            isLiked = menuLikeSummary.getIsLiked(),
-            likeCnt = menuLikeSummary.getLikeCnt(),
-        )
+        return MenuDetailsDto.from(menuSummary, menuLikeSummary)
     }
 
     fun postReview(
@@ -170,23 +155,7 @@ class ReviewService(
                 user.id.toString(),
             )
 
-        return MenuDetailsDto(
-            createdAt = review.createdAt,
-            updatedAt = review.updatedAt,
-            id = menuSummary.getId(),
-            restaurantId = menuSummary.getRestaurantId(),
-            code = menuSummary.getCode(),
-            date = menuSummary.getDate(),
-            type = menuSummary.getType(),
-            nameKr = menuSummary.getNameKr(),
-            nameEn = menuSummary.getNameEn(),
-            price = menuSummary.getPrice(),
-            etc = EtcUtils.convertMenuEtc(menuSummary.getEtc()),
-            score = menuSummary.getScore(),
-            reviewCnt = menuSummary.getReviewCnt(),
-            isLiked = menuLikeSummary.getIsLiked(),
-            likeCnt = menuLikeSummary.getLikeCnt(),
-        )
+        return MenuDetailsDto.from(menuSummary, menuLikeSummary)
     }
 
     fun getReviews(
@@ -195,7 +164,7 @@ class ReviewService(
         page: Int,
         size: Int,
     ): ReviewListResponse {
-        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "created_at"))
         val reviews = reviewRepository.findByMenuIdOrderByCreatedAtDesc(userId, menuId, pageable)
         val totalCount = reviewRepository.countByMenuId(menuId)
         val hasNext = page * size < totalCount
@@ -243,7 +212,7 @@ class ReviewService(
         page: Int,
         size: Int,
     ): ReviewListResponse {
-        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "created_at"))
         val reviews = reviewRepository.findFilteredReviews(userId, menuId, comment, etc, pageable)
         val totalCount = reviewRepository.countFilteredReviews(menuId, comment, etc)
         val hasNext = page * size < totalCount
@@ -265,7 +234,7 @@ class ReviewService(
         page: Int,
         size: Int,
     ): ReviewListResponse {
-        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "created_at"))
         val reviews = reviewRepository.findByUserId(userId, pageable)
         val totalCount = reviewRepository.countByUserId(userId)
         val hasNext = page * size < totalCount
@@ -296,6 +265,7 @@ class ReviewService(
         reviewLikeRepository.save(reviewLike)
     }
 
+    @Transactional
     fun unlikeReview(
         reviewId: Int,
         userId: Int,

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
@@ -17,6 +17,7 @@ import siksha.wafflestudio.core.domain.main.menu.dto.MenuDetailsDto
 import siksha.wafflestudio.core.domain.main.menu.repository.MenuRepository
 import siksha.wafflestudio.core.domain.main.review.data.KeywordReview
 import siksha.wafflestudio.core.domain.main.review.data.Review
+import siksha.wafflestudio.core.domain.main.review.data.ReviewLike
 import siksha.wafflestudio.core.domain.main.review.dto.CommentRecommendationResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewListResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewRequest
@@ -24,6 +25,7 @@ import siksha.wafflestudio.core.domain.main.review.dto.ReviewResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewScoreDistributionResponse
 import siksha.wafflestudio.core.domain.main.review.dto.ReviewWithImagesRequest
 import siksha.wafflestudio.core.domain.main.review.repository.KeywordReviewRepository
+import siksha.wafflestudio.core.domain.main.review.repository.ReviewLikeRepository
 import siksha.wafflestudio.core.domain.main.review.repository.ReviewRepository
 import siksha.wafflestudio.core.domain.user.repository.UserRepository
 import siksha.wafflestudio.core.infrastructure.s3.S3ImagePrefix
@@ -40,6 +42,7 @@ class ReviewService(
     private val menuRepository: MenuRepository,
     private val imageRepository: ImageRepository,
     private val keywordReviewRepository: KeywordReviewRepository,
+    private val reviewLikeRepository: ReviewLikeRepository,
     private val s3Service: S3Service,
 ) {
     @Autowired
@@ -275,5 +278,27 @@ class ReviewService(
             hasNext = hasNext,
             result = result,
         )
+    }
+
+    fun likeReview(
+        reviewId: Int,
+        userId: Int,
+    ) {
+        val user = userRepository.getReferenceById(userId)
+        val review = reviewRepository.getReferenceById(reviewId)
+        val reviewLike = ReviewLike(
+            id = 0,
+            user = user,
+            review = review,
+        )
+        reviewLikeRepository.save(reviewLike)
+    }
+
+    fun unlikeReview(
+        reviewId: Int,
+        userId: Int,
+    ): Boolean {
+        val deleteCount = reviewLikeRepository.deleteByUserIdAndReviewId(userId, reviewId)
+        return deleteCount > 0
     }
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
@@ -72,7 +72,6 @@ class ReviewService(
 
         validatePartialEmptyFields(tasteKeyword, priceKeyword, foodCompositionKeyword)
 
-
         val uploadedFiles =
             images?.takeIf { it.isNotEmpty() }?.let {
                 s3Service.uploadFiles(
@@ -95,25 +94,24 @@ class ReviewService(
 
         val imageUrls = uploadedFiles.map { it.url }
 
-
         val review: Review
         try {
-            review = reviewRepository.save(
-                Review(
-                    user = user,
-                    menu = menu,
-                    score = score,
-                    comment = comment ?: "",
-                    etc = objectMapper.writeValueAsString(imageUrls),
-                    // 이미지 URL 들을 JSON array로 저장
-                ),
-            )
+            review =
+                reviewRepository.save(
+                    Review(
+                        user = user,
+                        menu = menu,
+                        score = score,
+                        comment = comment ?: "",
+                        etc = objectMapper.writeValueAsString(imageUrls),
+                        // 이미지 URL 들을 JSON array로 저장
+                    ),
+                )
         } catch (ex: DataIntegrityViolationException) {
             throw ReviewAlreadyExistsException()
         } catch (ex: Exception) {
             throw ReviewSaveFailedException()
         }
-
 
         keywordReviewRepository.save(
             KeywordReview(
@@ -122,7 +120,7 @@ class ReviewService(
                 foodComposition = KeywordReviewUtil.getFoodCompositionLevel(foodCompositionKeyword),
                 review = review,
                 menu = menu,
-            )
+            ),
         )
 
         val menuSummary = menuRepository.findMenuById(menu.id.toString())
@@ -175,7 +173,7 @@ class ReviewService(
                 foodComposition = KeywordReviewUtil.getFoodCompositionLevel(request.foodComposition),
                 review = review,
                 menu = menu,
-            )
+            ),
         )
 
         val menuSummary = menuRepository.findMenuById(menu.id.toString())
@@ -198,9 +196,13 @@ class ReviewService(
 
         val menuPlainSummary = menuRepository.findPlainMenuById(menuId.toString())
 
-        val reviews = reviewRepository.findByMenuIdOrderByCreatedAtDesc(
-            userId, menuPlainSummary.getRestaurantId(), menuPlainSummary.getCode(), pageable
-        )
+        val reviews =
+            reviewRepository.findByMenuIdOrderByCreatedAtDesc(
+                userId,
+                menuPlainSummary.getRestaurantId(),
+                menuPlainSummary.getCode(),
+                pageable,
+            )
         val totalCount = reviewRepository.countByMenuId(menuPlainSummary.getRestaurantId(), menuPlainSummary.getCode())
         val hasNext = page * size < totalCount
 
@@ -228,9 +230,11 @@ class ReviewService(
     fun getScoreDistribution(menuId: Int): ReviewScoreDistributionResponse {
         val menuPlainSummary: MenuPlainSummary = menuRepository.findPlainMenuById(menuId.toString())
 
-        val counts = reviewRepository.findScoreCountsByMenuId(
-            menuPlainSummary.getRestaurantId(), menuPlainSummary.getCode()
-        )
+        val counts =
+            reviewRepository.findScoreCountsByMenuId(
+                menuPlainSummary.getRestaurantId(),
+                menuPlainSummary.getCode(),
+            )
 
         val dist = MutableList(5) { 0 } // [0, 0, 0, 0, 0]
 
@@ -244,7 +248,7 @@ class ReviewService(
     }
 
     fun getKeywordScoreDistribution(menuId: Int): KeywordScoreDistributionResponse {
-        val menu: MenuPlainSummary = menuRepository.findPlainMenuById(menuId.toString());
+        val menu: MenuPlainSummary = menuRepository.findPlainMenuById(menuId.toString())
         val keywordReviewSummary: KeywordReviewSummary =
             keywordReviewRepository.findScoreCountsByRestaurantIdAndCode(menu.getRestaurantId(), menu.getCode())
                 ?: return KeywordScoreDistributionResponse()
@@ -262,12 +266,22 @@ class ReviewService(
         val menuPlainSummary: MenuPlainSummary = menuRepository.findPlainMenuById(menuId.toString())
 
         val pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "created_at"))
-        val reviews = reviewRepository.findFilteredReviews(
-            userId, menuPlainSummary.getRestaurantId(), menuPlainSummary.getCode(), comment, etc, pageable
-        )
-        val totalCount = reviewRepository.countFilteredReviews(
-            menuPlainSummary.getRestaurantId(), menuPlainSummary.getCode(), comment, etc
-        )
+        val reviews =
+            reviewRepository.findFilteredReviews(
+                userId,
+                menuPlainSummary.getRestaurantId(),
+                menuPlainSummary.getCode(),
+                comment,
+                etc,
+                pageable,
+            )
+        val totalCount =
+            reviewRepository.countFilteredReviews(
+                menuPlainSummary.getRestaurantId(),
+                menuPlainSummary.getCode(),
+                comment,
+                etc,
+            )
         val hasNext = page * size < totalCount
 
         val result =
@@ -313,11 +327,12 @@ class ReviewService(
 
         if (review.user == user) throw SelfReviewLikeNotAllowedException()
 
-        val reviewLike = ReviewLike(
-            id = 0,
-            user = user,
-            review = review,
-        )
+        val reviewLike =
+            ReviewLike(
+                id = 0,
+                user = user,
+                review = review,
+            )
         reviewLikeRepository.save(reviewLike)
     }
 

--- a/core/src/main/kotlin/siksha/wafflestudio/core/util/KeywordReviewUtil.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/util/KeywordReviewUtil.kt
@@ -1,0 +1,37 @@
+package siksha.wafflestudio.core.util
+
+object KeywordReviewUtil {
+    private val flavorGrade = listOf("별로예요", "아쉬운 맛이에요", "무난해요", "생각보다 맛있어요", "또 먹고 싶어요")
+    private val priceGrade = listOf("너무 비싸요", "약간 비싸요", "합리적이에요", "가성비 좋아요", "혜자스러워요")
+    private val foodCompositionGrade = listOf("너무 빈약해요", "다소 단조로워요", "기본적이에요", "알찬 편이에요", "조화로워요")
+
+    fun getFlavorKeyword(flavorLevel: Int?): String {
+        if (flavorLevel == null || flavorLevel == -1) return ""
+        return flavorGrade[flavorLevel]
+    }
+
+    fun getPriceKeyword(priceLevel: Int?): String {
+        if (priceLevel == null || priceLevel == -1) return ""
+        return priceGrade[priceLevel]
+    }
+
+    fun getFoodCompositionKeyword(foodLevel: Int?): String {
+        if (foodLevel == null || foodLevel == -1) return ""
+        return foodCompositionGrade[foodLevel]
+    }
+
+    fun getFlavorLevel(flavorKeyword: String?): Int {
+        if (flavorKeyword == null) return -1
+        return flavorGrade.indexOf(flavorKeyword)
+    }
+
+    fun getPriceLevel(priceKeyword: String?): Int {
+        if (priceKeyword == null) return -1
+        return priceGrade.indexOf(priceKeyword)
+    }
+
+    fun getFoodCompositionLevel(foodKeyword: String?): Int {
+        if (foodKeyword == null) return -1
+        return foodCompositionGrade.indexOf(foodKeyword)
+    }
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/util/KeywordReviewUtil.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/util/KeywordReviewUtil.kt
@@ -1,37 +1,37 @@
 package siksha.wafflestudio.core.util
 
 object KeywordReviewUtil {
-    private val flavorGrade = listOf("별로예요", "아쉬운 맛이에요", "무난해요", "생각보다 맛있어요", "또 먹고 싶어요")
+    private val tasteGrade = listOf("별로예요", "아쉬운 맛이에요", "무난해요", "생각보다 맛있어요", "또 먹고 싶어요")
     private val priceGrade = listOf("너무 비싸요", "약간 비싸요", "합리적이에요", "가성비 좋아요", "혜자스러워요")
     private val foodCompositionGrade = listOf("너무 빈약해요", "다소 단조로워요", "기본적이에요", "알찬 편이에요", "조화로워요")
 
-    fun getFlavorKeyword(flavorLevel: Int?): String {
-        if (flavorLevel == null || flavorLevel == -1) return ""
-        return flavorGrade[flavorLevel]
+    fun getTasteKeyword(tasteLevel: Int?): String {
+        if (tasteLevel == null || tasteLevel == -1 || tasteLevel > 4) return ""
+        return tasteGrade[tasteLevel]
     }
 
     fun getPriceKeyword(priceLevel: Int?): String {
-        if (priceLevel == null || priceLevel == -1) return ""
+        if (priceLevel == null || priceLevel == -1 || priceLevel > 4) return ""
         return priceGrade[priceLevel]
     }
 
     fun getFoodCompositionKeyword(foodLevel: Int?): String {
-        if (foodLevel == null || foodLevel == -1) return ""
+        if (foodLevel == null || foodLevel == -1 || foodLevel > 4) return ""
         return foodCompositionGrade[foodLevel]
     }
 
-    fun getFlavorLevel(flavorKeyword: String?): Int {
-        if (flavorKeyword == null) return -1
-        return flavorGrade.indexOf(flavorKeyword)
+    fun getTasteLevel(tasteKeyword: String?): Int {
+        if (tasteKeyword == null || !tasteGrade.contains(tasteKeyword)) return -1
+        return tasteGrade.indexOf(tasteKeyword)
     }
 
     fun getPriceLevel(priceKeyword: String?): Int {
-        if (priceKeyword == null) return -1
+        if (priceKeyword == null || !priceGrade.contains(priceKeyword)) return -1
         return priceGrade.indexOf(priceKeyword)
     }
 
     fun getFoodCompositionLevel(foodKeyword: String?): Int {
-        if (foodKeyword == null) return -1
+        if (foodKeyword == null || !foodKeyword.contains(foodKeyword)) return -1
         return foodCompositionGrade.indexOf(foodKeyword)
     }
 }

--- a/core/src/main/resources/db/migration/V1__init.sql
+++ b/core/src/main/resources/db/migration/V1__init.sql
@@ -307,3 +307,43 @@ create table if not exists review
 create index review_user_id_index
     on review (user_id);
 
+create table if not exists keyword_review (
+    review_id           int
+        primary key,
+    taste               int                          not null comment '맛 평가 점수',
+    price               int                          not null comment '가격 평가 점수',
+    food_composition    int                          not null comment '음식 구성 평가 점수',
+    restaurant_id       int                          not null comment '리뷰한 메뉴의 레스토랑 id',
+    menu_code           varchar(200)                 not null comment '리뷰한 메뉴의 식별자',
+    menu_date           date                         not null comment '리뷰한 메뉴의 날짜',
+    menu_type           varchar(10)                  not null comment '리뷰한 메뉴의 타입',
+    constraint keyword_review_ibfk_1
+        foreign key (review_id) references review (id)
+        on delete cascade,
+    constraint keyword_review_ibfk_2
+        foreign key (restaurant_id, menu_code, menu_date, menu_type) references menu (restaurant_id, code, date, type)
+        on delete cascade
+);
+
+create index keyword_review_menu_key_index
+    on keyword_review (restaurant_id, menu_code);
+
+create table if not exists review_like (
+    id         int auto_increment
+        primary key,
+    user_id    int                                 not null comment '리뷰를 좋아한 사용자의 id',
+    review_id  int                                 not null comment '사용자가 좋아한 리뷰 id',
+    created_at timestamp default CURRENT_TIMESTAMP not null comment '생성 시간',
+    updated_at timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '변경 시간',
+    constraint review_id
+        unique (review_id, user_id),
+    constraint review_like_ibfk_1
+        foreign key (user_id) references user (id)
+        on delete cascade,
+    constraint review_like_ibfk_2
+        foreign key (review_id) references review (id)
+        on delete cascade
+);
+
+create index review_like_review_id_index
+    on review_like (review_id);

--- a/core/src/test/kotlin/repository/review/KeywordReviewTest.kt
+++ b/core/src/test/kotlin/repository/review/KeywordReviewTest.kt
@@ -61,13 +61,14 @@ class KeywordReviewTest {
                 ),
             )
 
-        val keywordReview = KeywordReview(
-            review = review,
-            menu = menu,
-            taste = 4,
-            price = 3,
-            foodComposition = 3
-        )
+        val keywordReview =
+            KeywordReview(
+                review = review,
+                menu = menu,
+                taste = 4,
+                price = 3,
+                foodComposition = 3,
+            )
 
         // when
         val savedKeywordReview = keywordReviewRepository.save(keywordReview)
@@ -119,24 +120,26 @@ class KeywordReviewTest {
                 ),
             )
 
-        val keywordReview = KeywordReview(
-            review = review,
-            menu = menu,
-            taste = 2,
-            price = 2,
-            foodComposition = 2
-        )
+        val keywordReview =
+            KeywordReview(
+                review = review,
+                menu = menu,
+                taste = 2,
+                price = 2,
+                foodComposition = 2,
+            )
 
         val savedKeywordReview = keywordReviewRepository.save(keywordReview)
         entityManager.flush()
         entityManager.clear()
 
         // when
-        val updatedKeywordReview = savedKeywordReview.copy(
-            taste = 5,
-            price = 4,
-            foodComposition = 4
-        )
+        val updatedKeywordReview =
+            savedKeywordReview.copy(
+                taste = 5,
+                price = 4,
+                foodComposition = 4,
+            )
         val result = keywordReviewRepository.save(updatedKeywordReview)
         entityManager.flush()
         entityManager.clear()
@@ -185,13 +188,14 @@ class KeywordReviewTest {
                 ),
             )
 
-        val keywordReview = KeywordReview(
-            review = review,
-            menu = menu,
-            taste = 3,
-            price = 3,
-            foodComposition = 3
-        )
+        val keywordReview =
+            KeywordReview(
+                review = review,
+                menu = menu,
+                taste = 3,
+                price = 3,
+                foodComposition = 3,
+            )
 
         val savedKeywordReview = keywordReviewRepository.save(keywordReview)
         entityManager.flush()

--- a/core/src/test/kotlin/repository/review/KeywordReviewTest.kt
+++ b/core/src/test/kotlin/repository/review/KeywordReviewTest.kt
@@ -1,0 +1,209 @@
+package siksha.wafflestudio.core.repository.review
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import siksha.wafflestudio.core.domain.main.menu.data.Menu
+import siksha.wafflestudio.core.domain.main.restaurant.data.Restaurant
+import siksha.wafflestudio.core.domain.main.review.data.KeywordReview
+import siksha.wafflestudio.core.domain.main.review.data.Review
+import siksha.wafflestudio.core.domain.main.review.repository.KeywordReviewRepository
+import siksha.wafflestudio.core.domain.user.data.User
+import java.time.LocalDate
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class KeywordReviewTest {
+    @Autowired
+    private lateinit var keywordReviewRepository: KeywordReviewRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+    @Test
+    fun `save keyword review`() {
+        // given
+        val user = entityManager.find(User::class.java, 1L)
+        assertNotNull(user)
+
+        val restaurant = entityManager.find(Restaurant::class.java, 1L)
+        assertNotNull(restaurant)
+
+        val menu =
+            entityManager.persist(
+                Menu(
+                    id = 0,
+                    restaurant = restaurant,
+                    code = "TEST_MENU",
+                    date = LocalDate.now(),
+                    type = "LU",
+                    nameKr = "테스트 메뉴",
+                    nameEn = "Test Menu",
+                    price = 10000,
+                    etc = "[]",
+                ),
+            )
+
+        val review =
+            entityManager.persist(
+                Review(
+                    id = 0,
+                    user = user,
+                    menu = menu,
+                    score = 5,
+                    comment = "맛있어요!",
+                    etc = null,
+                ),
+            )
+
+        val keywordReview = KeywordReview(
+            review = review,
+            menu = menu,
+            taste = 4,
+            price = 3,
+            foodComposition = 3
+        )
+
+        // when
+        val savedKeywordReview = keywordReviewRepository.save(keywordReview)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        assertNotNull(savedKeywordReview)
+        assertEquals(review.id, keywordReview.review.id)
+        assertEquals(menu.restaurant.id, keywordReview.menu.restaurant.id)
+        assertEquals(4, keywordReview.taste)
+        assertEquals(3, keywordReview.price)
+        assertEquals(3, keywordReview.foodComposition)
+    }
+
+    @Test
+    fun `update keyword review`() {
+        // given
+        val user = entityManager.find(User::class.java, 1L)
+        assertNotNull(user)
+
+        val restaurant = entityManager.find(Restaurant::class.java, 1L)
+        assertNotNull(restaurant)
+
+        val menu =
+            entityManager.persist(
+                Menu(
+                    id = 0,
+                    restaurant = restaurant,
+                    code = "TEST_MENU_UPDATE",
+                    date = LocalDate.now(),
+                    type = "DN",
+                    nameKr = "업데이트 테스트 메뉴",
+                    nameEn = "Update Test Menu",
+                    price = 12000,
+                    etc = "[]",
+                ),
+            )
+
+        val review =
+            entityManager.persist(
+                Review(
+                    id = 0,
+                    user = user,
+                    menu = menu,
+                    score = 3,
+                    comment = "업데이트 테스트용 리뷰",
+                    etc = null,
+                ),
+            )
+
+        val keywordReview = KeywordReview(
+            review = review,
+            menu = menu,
+            taste = 2,
+            price = 2,
+            foodComposition = 2
+        )
+
+        val savedKeywordReview = keywordReviewRepository.save(keywordReview)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        val updatedKeywordReview = savedKeywordReview.copy(
+            taste = 5,
+            price = 4,
+            foodComposition = 4
+        )
+        val result = keywordReviewRepository.save(updatedKeywordReview)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val foundKeywordReview = keywordReviewRepository.findById(result.review.id)
+        assertNotNull(foundKeywordReview.orElse(null))
+        assertEquals(5, foundKeywordReview.get().taste)
+        assertEquals(4, foundKeywordReview.get().price)
+        assertEquals(4, foundKeywordReview.get().foodComposition)
+    }
+
+    @Test
+    fun `delete keyword review`() {
+        // given
+        val user = entityManager.find(User::class.java, 1L)
+        assertNotNull(user)
+
+        val restaurant = entityManager.find(Restaurant::class.java, 1L)
+        assertNotNull(restaurant)
+
+        val menu =
+            entityManager.persist(
+                Menu(
+                    id = 0,
+                    restaurant = restaurant,
+                    code = "TEST_MENU_DELETE",
+                    date = LocalDate.now(),
+                    type = "BR",
+                    nameKr = "삭제 테스트 메뉴",
+                    nameEn = "Delete Test Menu",
+                    price = 8000,
+                    etc = "[]",
+                ),
+            )
+
+        val review =
+            entityManager.persist(
+                Review(
+                    id = 0,
+                    user = user,
+                    menu = menu,
+                    score = 4,
+                    comment = "삭제 테스트용 리뷰",
+                    etc = null,
+                ),
+            )
+
+        val keywordReview = KeywordReview(
+            review = review,
+            menu = menu,
+            taste = 3,
+            price = 3,
+            foodComposition = 3
+        )
+
+        val savedKeywordReview = keywordReviewRepository.save(keywordReview)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        keywordReviewRepository.delete(savedKeywordReview)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val deletedKeywordReview = keywordReviewRepository.findById(savedKeywordReview.review.id)
+        assertNull(deletedKeywordReview.orElse(null))
+    }
+}

--- a/core/src/test/kotlin/repository/review/ReviewLikeTest.kt
+++ b/core/src/test/kotlin/repository/review/ReviewLikeTest.kt
@@ -73,16 +73,17 @@ class ReviewLikeTest {
                     updatedAt = OffsetDateTime.now(),
                     nickname = "자반고등어구이",
                     profileUrl = null,
-                )
+                ),
             )
 
-        val reviewLike = ReviewLike(
-            id = 0,
-            user = user2,
-            review = review,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-        )
+        val reviewLike =
+            ReviewLike(
+                id = 0,
+                user = user2,
+                review = review,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         // when
         val savedReviewLike = reviewLikeRepository.save(reviewLike)
@@ -140,16 +141,17 @@ class ReviewLikeTest {
                     updatedAt = OffsetDateTime.now(),
                     nickname = "삭제테스트유저",
                     profileUrl = null,
-                )
+                ),
             )
 
-        val reviewLike = ReviewLike(
-            id = 0,
-            user = user2,
-            review = review,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-        )
+        val reviewLike =
+            ReviewLike(
+                id = 0,
+                user = user2,
+                review = review,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         val savedReviewLike = reviewLikeRepository.save(reviewLike)
         entityManager.flush()

--- a/core/src/test/kotlin/repository/review/ReviewLikeTest.kt
+++ b/core/src/test/kotlin/repository/review/ReviewLikeTest.kt
@@ -1,0 +1,167 @@
+package siksha.wafflestudio.core.repository.review
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import siksha.wafflestudio.core.domain.main.menu.data.Menu
+import siksha.wafflestudio.core.domain.main.restaurant.data.Restaurant
+import siksha.wafflestudio.core.domain.main.review.data.Review
+import siksha.wafflestudio.core.domain.main.review.data.ReviewLike
+import siksha.wafflestudio.core.domain.main.review.repository.ReviewLikeRepository
+import siksha.wafflestudio.core.domain.user.data.User
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ReviewLikeTest {
+    @Autowired
+    private lateinit var reviewLikeRepository: ReviewLikeRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+    @Test
+    fun `save review like`() {
+        // given
+        val user = entityManager.find(User::class.java, 1L)
+        assertNotNull(user)
+
+        val restaurant = entityManager.find(Restaurant::class.java, 1L)
+        assertNotNull(restaurant)
+
+        val menu =
+            entityManager.persist(
+                Menu(
+                    id = 0,
+                    restaurant = restaurant,
+                    code = "TEST_MENU",
+                    date = LocalDate.now(),
+                    type = "LU",
+                    nameKr = "테스트 메뉴",
+                    nameEn = "Test Menu",
+                    price = 10000,
+                    etc = "[]",
+                ),
+            )
+
+        val review =
+            entityManager.persist(
+                Review(
+                    id = 0,
+                    user = user,
+                    menu = menu,
+                    score = 5,
+                    comment = "맛있어요!",
+                    etc = null,
+                ),
+            )
+
+        val user2 =
+            entityManager.persist(
+                User(
+                    id = 0,
+                    type = "KAKAO",
+                    identity = "00000002",
+                    etc = null,
+                    createdAt = OffsetDateTime.now(),
+                    updatedAt = OffsetDateTime.now(),
+                    nickname = "자반고등어구이",
+                    profileUrl = null,
+                )
+            )
+
+        val reviewLike = ReviewLike(
+            id = 0,
+            user = user2,
+            review = review,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+        )
+
+        // when
+        val savedReviewLike = reviewLikeRepository.save(reviewLike)
+
+        // then
+        assertNotNull(savedReviewLike)
+        assertEquals(review.id, savedReviewLike.review.id)
+        assertEquals(user2.id, savedReviewLike.user.id)
+    }
+
+    @Test
+    fun `delete review like`() {
+        // given
+        val user = entityManager.find(User::class.java, 1L)
+        assertNotNull(user)
+
+        val restaurant = entityManager.find(Restaurant::class.java, 1L)
+        assertNotNull(restaurant)
+
+        val menu =
+            entityManager.persist(
+                Menu(
+                    id = 0,
+                    restaurant = restaurant,
+                    code = "TEST_MENU_DELETE",
+                    date = LocalDate.now(),
+                    type = "LU",
+                    nameKr = "삭제 테스트 메뉴",
+                    nameEn = "Delete Test Menu",
+                    price = 15000,
+                    etc = "[]",
+                ),
+            )
+
+        val review =
+            entityManager.persist(
+                Review(
+                    id = 0,
+                    user = user,
+                    menu = menu,
+                    score = 4,
+                    comment = "삭제 테스트용 리뷰",
+                    etc = null,
+                ),
+            )
+
+        val user2 =
+            entityManager.persist(
+                User(
+                    id = 0,
+                    type = "GOOGLE",
+                    identity = "00000003",
+                    etc = null,
+                    createdAt = OffsetDateTime.now(),
+                    updatedAt = OffsetDateTime.now(),
+                    nickname = "삭제테스트유저",
+                    profileUrl = null,
+                )
+            )
+
+        val reviewLike = ReviewLike(
+            id = 0,
+            user = user2,
+            review = review,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+        )
+
+        val savedReviewLike = reviewLikeRepository.save(reviewLike)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        reviewLikeRepository.delete(savedReviewLike)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val deletedReviewLike = reviewLikeRepository.findById(savedReviewLike.id)
+        assertNull(deletedReviewLike.orElse(null))
+    }
+}

--- a/core/src/test/kotlin/service/review/ReviewServiceTest.kt
+++ b/core/src/test/kotlin/service/review/ReviewServiceTest.kt
@@ -1,0 +1,652 @@
+package siksha.wafflestudio.core.service.review
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import siksha.wafflestudio.core.domain.common.exception.CommentNotFoundException
+import siksha.wafflestudio.core.domain.common.exception.InvalidScoreException
+import siksha.wafflestudio.core.domain.common.exception.KeywordMissingException
+import siksha.wafflestudio.core.domain.common.exception.MenuNotFoundException
+import siksha.wafflestudio.core.domain.common.exception.ReviewAlreadyExistsException
+import siksha.wafflestudio.core.domain.common.exception.SelfReviewLikeNotAllowedException
+import siksha.wafflestudio.core.domain.common.exception.UserNotFoundException
+import java.util.Optional
+import siksha.wafflestudio.core.domain.image.repository.ImageRepository
+import siksha.wafflestudio.core.domain.main.menu.data.Menu
+import siksha.wafflestudio.core.domain.main.menu.dto.MenuLikeSummary
+import siksha.wafflestudio.core.domain.main.menu.dto.MenuPlainSummary
+import siksha.wafflestudio.core.domain.main.menu.dto.MenuSummary
+import siksha.wafflestudio.core.domain.main.menu.repository.MenuRepository
+import siksha.wafflestudio.core.domain.main.restaurant.data.Restaurant
+import siksha.wafflestudio.core.domain.main.review.data.KeywordReview
+import siksha.wafflestudio.core.domain.main.review.data.Review
+import siksha.wafflestudio.core.domain.main.review.data.ReviewLike
+import siksha.wafflestudio.core.domain.main.review.dto.ReviewRequest
+import siksha.wafflestudio.core.domain.main.review.dto.ReviewSummary
+import siksha.wafflestudio.core.domain.main.review.repository.KeywordReviewRepository
+import siksha.wafflestudio.core.domain.main.review.repository.ReviewLikeRepository
+import siksha.wafflestudio.core.domain.main.review.repository.ReviewRepository
+import siksha.wafflestudio.core.domain.main.review.service.ReviewService
+import siksha.wafflestudio.core.domain.user.data.User
+import siksha.wafflestudio.core.domain.user.repository.UserRepository
+import siksha.wafflestudio.core.infrastructure.s3.S3Service
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class ReviewServiceTest {
+
+    @Mock
+    private lateinit var reviewRepository: ReviewRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var menuRepository: MenuRepository
+
+    @Mock
+    private lateinit var keywordReviewRepository: KeywordReviewRepository
+
+    @Mock
+    private lateinit var reviewLikeRepository: ReviewLikeRepository
+
+    @Mock
+    private lateinit var imageRepository: ImageRepository
+
+    @Mock
+    private lateinit var s3Service: S3Service
+
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var reviewService: ReviewService
+
+    @BeforeEach
+    fun setUp() {
+        objectMapper = ObjectMapper()
+        reviewService = ReviewService(
+            reviewRepository = reviewRepository,
+            userRepository = userRepository,
+            menuRepository = menuRepository,
+            imageRepository = imageRepository,
+            keywordReviewRepository = keywordReviewRepository,
+            reviewLikeRepository = reviewLikeRepository,
+            s3Service = s3Service
+        )
+        // objectMapper는 private이므로 리플렉션을 사용하거나 다른 방법으로 설정
+        val field = ReviewService::class.java.getDeclaredField("objectMapper")
+        field.isAccessible = true
+        field.set(reviewService, objectMapper)
+    }
+
+    @Test
+    fun `postReview - 성공적으로 리뷰 작성`() {
+        // given
+        val userId = 1
+        val menuId = 1
+        val request = ReviewRequest(
+            menuId = menuId,
+            score = 5,
+            comment = "생각보다 맛있어요",
+            taste = "맛있음",
+            price = "혜자스러워요",
+            foodComposition = "알찬 편이에요"
+        )
+
+        val user = User(
+            id = userId,
+            type = "KAKAO",
+            identity = "test123",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "테스트유저",
+            profileUrl = null
+        )
+
+        val restaurant = Restaurant(
+            id = 1,
+            code = "REST001",
+            nameKr = "테스트식당",
+            nameEn = "Test Restaurant",
+            addr = "서울시",
+            lat = 37.5,
+            lng = 127.0,
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val menu = Menu(
+            id = menuId,
+            restaurant = restaurant,
+            code = "MENU001",
+            date = LocalDate.now(),
+            type = "LU",
+            nameKr = "테스트메뉴",
+            nameEn = "Test Menu",
+            price = 10000,
+            etc = "[]",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val savedReview = Review(
+            id = 1,
+            user = user,
+            menu = menu,
+            score = 5,
+            comment = "맛있어요!",
+            etc = "",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val menuSummary = mock<MenuSummary>()
+        `when`(menuSummary.getId()).thenReturn(menuId)
+        `when`(menuSummary.getRestaurantId()).thenReturn(1)
+        `when`(menuSummary.getCode()).thenReturn("MENU001")
+        `when`(menuSummary.getDate()).thenReturn(LocalDate.now())
+        `when`(menuSummary.getType()).thenReturn("LU")
+        `when`(menuSummary.getNameKr()).thenReturn("테스트메뉴")
+        `when`(menuSummary.getNameEn()).thenReturn("Test Menu")
+        `when`(menuSummary.getPrice()).thenReturn(10000)
+        `when`(menuSummary.getEtc()).thenReturn("[]")
+        `when`(menuSummary.getCreatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+        `when`(menuSummary.getUpdatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+        `when`(menuSummary.getScore()).thenReturn(4.5)
+        `when`(menuSummary.getReviewCnt()).thenReturn(10)
+
+        val menuLikeSummary = mock<MenuLikeSummary>()
+        `when`(menuLikeSummary.getIsLiked()).thenReturn(0)
+        `when`(menuLikeSummary.getLikeCnt()).thenReturn(0)
+
+        `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
+        `when`(menuRepository.findById(menuId)).thenReturn(Optional.of(menu))
+        `when`(reviewRepository.save(any(Review::class.java))).thenReturn(savedReview)
+        `when`(menuRepository.findMenuById(menuId.toString())).thenReturn(menuSummary)
+        `when`(menuRepository.findMenuLikeByMenuIdAndUserId(menuId.toString(), userId.toString())).thenReturn(menuLikeSummary)
+
+        // when
+        val result = reviewService.postReview(userId, request)
+
+        // then
+        assertNotNull(result)
+        verify(keywordReviewRepository).save(any(KeywordReview::class.java))
+    }
+
+    @Test
+    fun `postReview - 사용자를 찾을 수 없는 경우 예외 발생`() {
+        // given
+        val userId = 999
+        val request = ReviewRequest(
+            menuId = 1,
+            score = 5,
+            comment = "맛있어요!",
+            taste = "맛있음",
+            price = "적당함",
+            foodComposition = "균형잡힘"
+        )
+
+        `when`(userRepository.findById(userId)).thenReturn(Optional.empty())
+
+        // when & then
+        assertThrows(UserNotFoundException::class.java) {
+            reviewService.postReview(userId, request)
+        }
+    }
+
+    @Test
+    fun `postReview - 메뉴를 찾을 수 없는 경우 예외 발생`() {
+        // given
+        val userId = 1
+        val menuId = 999
+        val request = ReviewRequest(
+            menuId = menuId,
+            score = 5,
+            comment = "맛있어요!",
+            taste = "맛있음",
+            price = "적당함",
+            foodComposition = "균형잡힘"
+        )
+
+        val user = User(
+            id = userId,
+            type = "KAKAO",
+            identity = "test123",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "테스트유저",
+            profileUrl = null
+        )
+
+        `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
+        `when`(menuRepository.findById(menuId)).thenReturn(Optional.empty())
+
+        // when & then
+        assertThrows(MenuNotFoundException::class.java) {
+            reviewService.postReview(userId, request)
+        }
+    }
+
+    @Test
+    fun `postReview - 키워드가 부족한 경우 예외 발생`() {
+        // given
+        val userId = 1
+        val request = ReviewRequest(
+            menuId = 1,
+            score = 5,
+            comment = "맛있어요!",
+            taste = "맛있음",
+            price = "", // 빈 값
+            foodComposition = "" // 빈 값
+        )
+
+        // when & then
+        assertThrows(KeywordMissingException::class.java) {
+            reviewService.postReview(userId, request)
+        }
+    }
+
+    @Test
+    fun `postReview - 중복 리뷰 작성 시 예외 발생`() {
+        // given
+        val userId = 1
+        val menuId = 1
+        val request = ReviewRequest(
+            menuId = menuId,
+            score = 5,
+            comment = "맛있어요!",
+            taste = "맛있음",
+            price = "적당함",
+            foodComposition = "균형잡힘"
+        )
+
+        val user = User(
+            id = userId,
+            type = "KAKAO",
+            identity = "test123",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "테스트유저",
+            profileUrl = null
+        )
+
+        val restaurant = Restaurant(
+            id = 1,
+            code = "REST001",
+            nameKr = "테스트식당",
+            nameEn = "Test Restaurant",
+            addr = "서울시",
+            lat = 37.5,
+            lng = 127.0,
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val menu = Menu(
+            id = menuId,
+            restaurant = restaurant,
+            code = "MENU001",
+            date = LocalDate.now(),
+            type = "LU",
+            nameKr = "테스트메뉴",
+            nameEn = "Test Menu",
+            price = 10000,
+            etc = "[]",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
+        `when`(menuRepository.findById(menuId)).thenReturn(Optional.of(menu))
+        `when`(reviewRepository.save(any(Review::class.java))).thenThrow(DataIntegrityViolationException("Duplicate entry"))
+
+        // when & then
+        assertThrows(ReviewAlreadyExistsException::class.java) {
+            reviewService.postReview(userId, request)
+        }
+    }
+
+    @Test
+    fun `likeReview - 성공적으로 좋아요 추가`() {
+        // given
+        val reviewId = 1
+        val userId = 1
+
+        val user = User(
+            id = userId,
+            type = "KAKAO",
+            identity = "test123",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "테스트유저",
+            profileUrl = null
+        )
+
+        val otherUser = User(
+            id = 2,
+            type = "GOOGLE",
+            identity = "test456",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "다른유저",
+            profileUrl = null
+        )
+
+        val restaurant = Restaurant(
+            id = 1,
+            code = "REST001",
+            nameKr = "테스트식당",
+            nameEn = "Test Restaurant",
+            addr = "서울시",
+            lat = 37.5,
+            lng = 127.0,
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val menu = Menu(
+            id = 1,
+            restaurant = restaurant,
+            code = "MENU001",
+            date = LocalDate.now(),
+            type = "LU",
+            nameKr = "테스트메뉴",
+            nameEn = "Test Menu",
+            price = 10000,
+            etc = "[]",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val review = Review(
+            id = reviewId,
+            user = otherUser, // 다른 사용자의 리뷰
+            menu = menu,
+            score = 5,
+            comment = "맛있어요!",
+            etc = "",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        `when`(userRepository.getReferenceById(userId)).thenReturn(user)
+        `when`(reviewRepository.getReferenceById(reviewId)).thenReturn(review)
+
+        // when
+        reviewService.likeReview(reviewId, userId)
+
+        // then
+        verify(reviewLikeRepository).save(any(ReviewLike::class.java))
+    }
+
+    @Test
+    fun `likeReview - 자신의 리뷰에 좋아요 시 예외 발생`() {
+        // given
+        val reviewId = 1
+        val userId = 1
+
+        val user = User(
+            id = userId,
+            type = "KAKAO",
+            identity = "test123",
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            nickname = "테스트유저",
+            profileUrl = null
+        )
+
+        val restaurant = Restaurant(
+            id = 1,
+            code = "REST001",
+            nameKr = "테스트식당",
+            nameEn = "Test Restaurant",
+            addr = "서울시",
+            lat = 37.5,
+            lng = 127.0,
+            etc = null,
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val menu = Menu(
+            id = 1,
+            restaurant = restaurant,
+            code = "MENU001",
+            date = LocalDate.now(),
+            type = "LU",
+            nameKr = "테스트메뉴",
+            nameEn = "Test Menu",
+            price = 10000,
+            etc = "[]",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        val review = Review(
+            id = reviewId,
+            user = user, // 같은 사용자의 리뷰
+            menu = menu,
+            score = 5,
+            comment = "맛있어요!",
+            etc = "",
+            createdAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now()
+        )
+
+        `when`(userRepository.getReferenceById(userId)).thenReturn(user)
+        `when`(reviewRepository.getReferenceById(reviewId)).thenReturn(review)
+
+        // when & then
+        assertThrows(SelfReviewLikeNotAllowedException::class.java) {
+            reviewService.likeReview(reviewId, userId)
+        }
+
+        verify(reviewLikeRepository, never()).save(any(ReviewLike::class.java))
+    }
+
+    @Test
+    fun `unlikeReview - 성공적으로 좋아요 취소`() {
+        // given
+        val reviewId = 1
+        val userId = 1
+
+        `when`(reviewLikeRepository.deleteByUserIdAndReviewId(userId, reviewId)).thenReturn(1)
+
+        // when
+        val result = reviewService.unlikeReview(reviewId, userId)
+
+        // then
+        assertEquals(true, result)
+        verify(reviewLikeRepository).deleteByUserIdAndReviewId(userId, reviewId)
+    }
+
+    @Test
+    fun `unlikeReview - 좋아요가 없는 경우 false 반환`() {
+        // given
+        val reviewId = 1
+        val userId = 1
+
+        `when`(reviewLikeRepository.deleteByUserIdAndReviewId(userId, reviewId)).thenReturn(0)
+
+        // when
+        val result = reviewService.unlikeReview(reviewId, userId)
+
+        // then
+        assertEquals(false, result)
+        verify(reviewLikeRepository).deleteByUserIdAndReviewId(userId, reviewId)
+    }
+
+    @Test
+    fun `getCommentRecommendation - 유효한 점수로 댓글 추천 성공`() {
+        // given
+        val score = 5
+        val expectedComment = "정말 맛있었어요!"
+
+        `when`(reviewRepository.findRandomCommentByScore(score)).thenReturn(expectedComment)
+
+        // when
+        val result = reviewService.getCommentRecommendation(score)
+
+        // then
+        assertNotNull(result)
+        assertEquals(expectedComment, result.comment)
+    }
+
+    @Test
+    fun `getCommentRecommendation - 잘못된 점수로 예외 발생`() {
+        // given
+        val invalidScore = 6
+
+        // when & then
+        assertThrows(InvalidScoreException::class.java) {
+            reviewService.getCommentRecommendation(invalidScore)
+        }
+    }
+
+    @Test
+    fun `getCommentRecommendation - 댓글을 찾을 수 없는 경우 예외 발생`() {
+        // given
+        val score = 3
+
+        `when`(reviewRepository.findRandomCommentByScore(score)).thenReturn(null)
+
+        // when & then
+        assertThrows(CommentNotFoundException::class.java) {
+            reviewService.getCommentRecommendation(score)
+        }
+    }
+
+    @Test
+    fun `getScoreDistribution - 점수 분포 조회 성공`() {
+        // given
+        val menuId = 1
+        val menuPlainSummary = mock<MenuPlainSummary>()
+        `when`(menuPlainSummary.getRestaurantId()).thenReturn(1)
+        `when`(menuPlainSummary.getCode()).thenReturn("MENU001")
+
+        val scoreCounts = listOf(
+            arrayOf<Any>(5, 10), // 점수 5: 10개
+            arrayOf<Any>(4, 5),  // 점수 4: 5개
+            arrayOf<Any>(3, 2),  // 점수 3: 2개
+            arrayOf<Any>(2, 1),  // 점수 2: 1개
+            arrayOf<Any>(1, 0)   // 점수 1: 0개
+        )
+
+        `when`(menuRepository.findPlainMenuById(menuId.toString())).thenReturn(menuPlainSummary)
+        `when`(reviewRepository.findScoreCountsByMenuId(1, "MENU001")).thenReturn(scoreCounts)
+
+        // when
+        val result = reviewService.getScoreDistribution(menuId)
+
+        // then
+        assertNotNull(result)
+        assertEquals(listOf(0, 1, 2, 5, 10), result.dist)
+    }
+
+    @Test
+    fun `getMyReviews - 내 리뷰 목록 조회 성공`() {
+        // given
+        val userId = 1
+        val page = 1
+        val size = 10
+
+        val reviewSummary = mock<ReviewSummary>()
+        `when`(reviewSummary.getId()).thenReturn(1)
+        `when`(reviewSummary.getMenuId()).thenReturn(1)
+        `when`(reviewSummary.getUserId()).thenReturn(userId)
+        `when`(reviewSummary.getScore()).thenReturn(5)
+        `when`(reviewSummary.getComment()).thenReturn("맛있어요!")
+        `when`(reviewSummary.getEtc()).thenReturn("")
+        `when`(reviewSummary.getTaste()).thenReturn(5)
+        `when`(reviewSummary.getPrice()).thenReturn(4)
+        `when`(reviewSummary.getFoodComposition()).thenReturn(4)
+        `when`(reviewSummary.getLikeCount()).thenReturn(3)
+        `when`(reviewSummary.getIsLiked()).thenReturn(0)
+        `when`(reviewSummary.getCreatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+        `when`(reviewSummary.getUpdatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+
+        val reviews = listOf(reviewSummary)
+        val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "created_at"))
+
+        `when`(reviewRepository.findByUserId(userId, pageable)).thenReturn(reviews)
+        `when`(reviewRepository.countByUserId(userId)).thenReturn(1L)
+
+        // when
+        val result = reviewService.getMyReviews(userId, page, size)
+
+        // then
+        assertNotNull(result)
+        assertEquals(1, result.totalCount)
+        assertEquals(false, result.hasNext)
+        assertEquals(1, result.result.size)
+    }
+
+    @Test
+    fun `getFilteredReviews - 필터링된 리뷰 조회 성공`() {
+        // given
+        val userId = 1
+        val menuId = 1
+        val comment = true
+        val etc = false
+        val page = 1
+        val size = 10
+
+        val menuPlainSummary = mock<MenuPlainSummary>()
+        `when`(menuPlainSummary.getRestaurantId()).thenReturn(1)
+        `when`(menuPlainSummary.getCode()).thenReturn("MENU001")
+
+        val reviewSummary = mock<ReviewSummary>()
+        `when`(reviewSummary.getId()).thenReturn(1)
+        `when`(reviewSummary.getMenuId()).thenReturn(1)
+        `when`(reviewSummary.getUserId()).thenReturn(userId)
+        `when`(reviewSummary.getScore()).thenReturn(5)
+        `when`(reviewSummary.getComment()).thenReturn("맛있어요!")
+        `when`(reviewSummary.getEtc()).thenReturn("")
+        `when`(reviewSummary.getTaste()).thenReturn(5)
+        `when`(reviewSummary.getPrice()).thenReturn(4)
+        `when`(reviewSummary.getFoodComposition()).thenReturn(4)
+        `when`(reviewSummary.getLikeCount()).thenReturn(3)
+        `when`(reviewSummary.getIsLiked()).thenReturn(0)
+        `when`(reviewSummary.getCreatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+        `when`(reviewSummary.getUpdatedAt()).thenReturn(Timestamp.valueOf(OffsetDateTime.now().toLocalDateTime()))
+
+        val reviews = listOf(reviewSummary)
+        val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "created_at"))
+
+        `when`(menuRepository.findPlainMenuById(menuId.toString())).thenReturn(menuPlainSummary)
+        `when`(reviewRepository.findFilteredReviews(userId, 1, "MENU001", comment, etc, pageable)).thenReturn(reviews)
+        `when`(reviewRepository.countFilteredReviews(1, "MENU001", comment, etc)).thenReturn(1L)
+
+        // when
+        val result = reviewService.getFilteredReviews(userId, menuId, comment, etc, page, size)
+
+        // then
+        assertNotNull(result)
+        assertEquals(1, result.totalCount)
+        assertEquals(false, result.hasNext)
+        assertEquals(1, result.result.size)
+    }
+}

--- a/core/src/test/kotlin/service/review/ReviewServiceTest.kt
+++ b/core/src/test/kotlin/service/review/ReviewServiceTest.kt
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.PageRequest
@@ -24,7 +24,6 @@ import siksha.wafflestudio.core.domain.common.exception.MenuNotFoundException
 import siksha.wafflestudio.core.domain.common.exception.ReviewAlreadyExistsException
 import siksha.wafflestudio.core.domain.common.exception.SelfReviewLikeNotAllowedException
 import siksha.wafflestudio.core.domain.common.exception.UserNotFoundException
-import java.util.Optional
 import siksha.wafflestudio.core.domain.image.repository.ImageRepository
 import siksha.wafflestudio.core.domain.main.menu.data.Menu
 import siksha.wafflestudio.core.domain.main.menu.dto.MenuLikeSummary
@@ -47,10 +46,10 @@ import siksha.wafflestudio.core.infrastructure.s3.S3Service
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class ReviewServiceTest {
-
     @Mock
     private lateinit var reviewRepository: ReviewRepository
 
@@ -78,15 +77,16 @@ class ReviewServiceTest {
     @BeforeEach
     fun setUp() {
         objectMapper = ObjectMapper()
-        reviewService = ReviewService(
-            reviewRepository = reviewRepository,
-            userRepository = userRepository,
-            menuRepository = menuRepository,
-            imageRepository = imageRepository,
-            keywordReviewRepository = keywordReviewRepository,
-            reviewLikeRepository = reviewLikeRepository,
-            s3Service = s3Service
-        )
+        reviewService =
+            ReviewService(
+                reviewRepository = reviewRepository,
+                userRepository = userRepository,
+                menuRepository = menuRepository,
+                imageRepository = imageRepository,
+                keywordReviewRepository = keywordReviewRepository,
+                reviewLikeRepository = reviewLikeRepository,
+                s3Service = s3Service,
+            )
         // objectMapper는 private이므로 리플렉션을 사용하거나 다른 방법으로 설정
         val field = ReviewService::class.java.getDeclaredField("objectMapper")
         field.isAccessible = true
@@ -98,63 +98,68 @@ class ReviewServiceTest {
         // given
         val userId = 1
         val menuId = 1
-        val request = ReviewRequest(
-            menuId = menuId,
-            score = 5,
-            comment = "생각보다 맛있어요",
-            taste = "맛있음",
-            price = "혜자스러워요",
-            foodComposition = "알찬 편이에요"
-        )
+        val request =
+            ReviewRequest(
+                menuId = menuId,
+                score = 5,
+                comment = "생각보다 맛있어요",
+                taste = "맛있음",
+                price = "혜자스러워요",
+                foodComposition = "알찬 편이에요",
+            )
 
-        val user = User(
-            id = userId,
-            type = "KAKAO",
-            identity = "test123",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "테스트유저",
-            profileUrl = null
-        )
+        val user =
+            User(
+                id = userId,
+                type = "KAKAO",
+                identity = "test123",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "테스트유저",
+                profileUrl = null,
+            )
 
-        val restaurant = Restaurant(
-            id = 1,
-            code = "REST001",
-            nameKr = "테스트식당",
-            nameEn = "Test Restaurant",
-            addr = "서울시",
-            lat = 37.5,
-            lng = 127.0,
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val restaurant =
+            Restaurant(
+                id = 1,
+                code = "REST001",
+                nameKr = "테스트식당",
+                nameEn = "Test Restaurant",
+                addr = "서울시",
+                lat = 37.5,
+                lng = 127.0,
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val menu = Menu(
-            id = menuId,
-            restaurant = restaurant,
-            code = "MENU001",
-            date = LocalDate.now(),
-            type = "LU",
-            nameKr = "테스트메뉴",
-            nameEn = "Test Menu",
-            price = 10000,
-            etc = "[]",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val menu =
+            Menu(
+                id = menuId,
+                restaurant = restaurant,
+                code = "MENU001",
+                date = LocalDate.now(),
+                type = "LU",
+                nameKr = "테스트메뉴",
+                nameEn = "Test Menu",
+                price = 10000,
+                etc = "[]",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val savedReview = Review(
-            id = 1,
-            user = user,
-            menu = menu,
-            score = 5,
-            comment = "맛있어요!",
-            etc = "",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val savedReview =
+            Review(
+                id = 1,
+                user = user,
+                menu = menu,
+                score = 5,
+                comment = "맛있어요!",
+                etc = "",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         val menuSummary = mock<MenuSummary>()
         `when`(menuSummary.getId()).thenReturn(menuId)
@@ -193,14 +198,15 @@ class ReviewServiceTest {
     fun `postReview - 사용자를 찾을 수 없는 경우 예외 발생`() {
         // given
         val userId = 999
-        val request = ReviewRequest(
-            menuId = 1,
-            score = 5,
-            comment = "맛있어요!",
-            taste = "맛있음",
-            price = "적당함",
-            foodComposition = "균형잡힘"
-        )
+        val request =
+            ReviewRequest(
+                menuId = 1,
+                score = 5,
+                comment = "맛있어요!",
+                taste = "맛있음",
+                price = "적당함",
+                foodComposition = "균형잡힘",
+            )
 
         `when`(userRepository.findById(userId)).thenReturn(Optional.empty())
 
@@ -215,25 +221,27 @@ class ReviewServiceTest {
         // given
         val userId = 1
         val menuId = 999
-        val request = ReviewRequest(
-            menuId = menuId,
-            score = 5,
-            comment = "맛있어요!",
-            taste = "맛있음",
-            price = "적당함",
-            foodComposition = "균형잡힘"
-        )
+        val request =
+            ReviewRequest(
+                menuId = menuId,
+                score = 5,
+                comment = "맛있어요!",
+                taste = "맛있음",
+                price = "적당함",
+                foodComposition = "균형잡힘",
+            )
 
-        val user = User(
-            id = userId,
-            type = "KAKAO",
-            identity = "test123",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "테스트유저",
-            profileUrl = null
-        )
+        val user =
+            User(
+                id = userId,
+                type = "KAKAO",
+                identity = "test123",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "테스트유저",
+                profileUrl = null,
+            )
 
         `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
         `when`(menuRepository.findById(menuId)).thenReturn(Optional.empty())
@@ -248,14 +256,15 @@ class ReviewServiceTest {
     fun `postReview - 키워드가 부족한 경우 예외 발생`() {
         // given
         val userId = 1
-        val request = ReviewRequest(
-            menuId = 1,
-            score = 5,
-            comment = "맛있어요!",
-            taste = "맛있음",
-            price = "", // 빈 값
-            foodComposition = "" // 빈 값
-        )
+        val request =
+            ReviewRequest(
+                menuId = 1,
+                score = 5,
+                comment = "맛있어요!",
+                taste = "맛있음",
+                price = "",
+                foodComposition = "",
+            )
 
         // when & then
         assertThrows(KeywordMissingException::class.java) {
@@ -268,52 +277,56 @@ class ReviewServiceTest {
         // given
         val userId = 1
         val menuId = 1
-        val request = ReviewRequest(
-            menuId = menuId,
-            score = 5,
-            comment = "맛있어요!",
-            taste = "맛있음",
-            price = "적당함",
-            foodComposition = "균형잡힘"
-        )
+        val request =
+            ReviewRequest(
+                menuId = menuId,
+                score = 5,
+                comment = "맛있어요!",
+                taste = "맛있음",
+                price = "적당함",
+                foodComposition = "균형잡힘",
+            )
 
-        val user = User(
-            id = userId,
-            type = "KAKAO",
-            identity = "test123",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "테스트유저",
-            profileUrl = null
-        )
+        val user =
+            User(
+                id = userId,
+                type = "KAKAO",
+                identity = "test123",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "테스트유저",
+                profileUrl = null,
+            )
 
-        val restaurant = Restaurant(
-            id = 1,
-            code = "REST001",
-            nameKr = "테스트식당",
-            nameEn = "Test Restaurant",
-            addr = "서울시",
-            lat = 37.5,
-            lng = 127.0,
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val restaurant =
+            Restaurant(
+                id = 1,
+                code = "REST001",
+                nameKr = "테스트식당",
+                nameEn = "Test Restaurant",
+                addr = "서울시",
+                lat = 37.5,
+                lng = 127.0,
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val menu = Menu(
-            id = menuId,
-            restaurant = restaurant,
-            code = "MENU001",
-            date = LocalDate.now(),
-            type = "LU",
-            nameKr = "테스트메뉴",
-            nameEn = "Test Menu",
-            price = 10000,
-            etc = "[]",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val menu =
+            Menu(
+                id = menuId,
+                restaurant = restaurant,
+                code = "MENU001",
+                date = LocalDate.now(),
+                type = "LU",
+                nameKr = "테스트메뉴",
+                nameEn = "Test Menu",
+                price = 10000,
+                etc = "[]",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
         `when`(menuRepository.findById(menuId)).thenReturn(Optional.of(menu))
@@ -331,65 +344,70 @@ class ReviewServiceTest {
         val reviewId = 1
         val userId = 1
 
-        val user = User(
-            id = userId,
-            type = "KAKAO",
-            identity = "test123",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "테스트유저",
-            profileUrl = null
-        )
+        val user =
+            User(
+                id = userId,
+                type = "KAKAO",
+                identity = "test123",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "테스트유저",
+                profileUrl = null,
+            )
 
-        val otherUser = User(
-            id = 2,
-            type = "GOOGLE",
-            identity = "test456",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "다른유저",
-            profileUrl = null
-        )
+        val otherUser =
+            User(
+                id = 2,
+                type = "GOOGLE",
+                identity = "test456",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "다른유저",
+                profileUrl = null,
+            )
 
-        val restaurant = Restaurant(
-            id = 1,
-            code = "REST001",
-            nameKr = "테스트식당",
-            nameEn = "Test Restaurant",
-            addr = "서울시",
-            lat = 37.5,
-            lng = 127.0,
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val restaurant =
+            Restaurant(
+                id = 1,
+                code = "REST001",
+                nameKr = "테스트식당",
+                nameEn = "Test Restaurant",
+                addr = "서울시",
+                lat = 37.5,
+                lng = 127.0,
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val menu = Menu(
-            id = 1,
-            restaurant = restaurant,
-            code = "MENU001",
-            date = LocalDate.now(),
-            type = "LU",
-            nameKr = "테스트메뉴",
-            nameEn = "Test Menu",
-            price = 10000,
-            etc = "[]",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val menu =
+            Menu(
+                id = 1,
+                restaurant = restaurant,
+                code = "MENU001",
+                date = LocalDate.now(),
+                type = "LU",
+                nameKr = "테스트메뉴",
+                nameEn = "Test Menu",
+                price = 10000,
+                etc = "[]",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val review = Review(
-            id = reviewId,
-            user = otherUser, // 다른 사용자의 리뷰
-            menu = menu,
-            score = 5,
-            comment = "맛있어요!",
-            etc = "",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val review =
+            Review(
+                id = reviewId,
+                user = otherUser,
+                menu = menu,
+                score = 5,
+                comment = "맛있어요!",
+                etc = "",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         `when`(userRepository.getReferenceById(userId)).thenReturn(user)
         `when`(reviewRepository.getReferenceById(reviewId)).thenReturn(review)
@@ -407,54 +425,58 @@ class ReviewServiceTest {
         val reviewId = 1
         val userId = 1
 
-        val user = User(
-            id = userId,
-            type = "KAKAO",
-            identity = "test123",
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-            nickname = "테스트유저",
-            profileUrl = null
-        )
+        val user =
+            User(
+                id = userId,
+                type = "KAKAO",
+                identity = "test123",
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+                nickname = "테스트유저",
+                profileUrl = null,
+            )
 
-        val restaurant = Restaurant(
-            id = 1,
-            code = "REST001",
-            nameKr = "테스트식당",
-            nameEn = "Test Restaurant",
-            addr = "서울시",
-            lat = 37.5,
-            lng = 127.0,
-            etc = null,
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val restaurant =
+            Restaurant(
+                id = 1,
+                code = "REST001",
+                nameKr = "테스트식당",
+                nameEn = "Test Restaurant",
+                addr = "서울시",
+                lat = 37.5,
+                lng = 127.0,
+                etc = null,
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val menu = Menu(
-            id = 1,
-            restaurant = restaurant,
-            code = "MENU001",
-            date = LocalDate.now(),
-            type = "LU",
-            nameKr = "테스트메뉴",
-            nameEn = "Test Menu",
-            price = 10000,
-            etc = "[]",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val menu =
+            Menu(
+                id = 1,
+                restaurant = restaurant,
+                code = "MENU001",
+                date = LocalDate.now(),
+                type = "LU",
+                nameKr = "테스트메뉴",
+                nameEn = "Test Menu",
+                price = 10000,
+                etc = "[]",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
-        val review = Review(
-            id = reviewId,
-            user = user, // 같은 사용자의 리뷰
-            menu = menu,
-            score = 5,
-            comment = "맛있어요!",
-            etc = "",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now()
-        )
+        val review =
+            Review(
+                id = reviewId,
+                user = user,
+                menu = menu,
+                score = 5,
+                comment = "맛있어요!",
+                etc = "",
+                createdAt = OffsetDateTime.now(),
+                updatedAt = OffsetDateTime.now(),
+            )
 
         `when`(userRepository.getReferenceById(userId)).thenReturn(user)
         `when`(reviewRepository.getReferenceById(reviewId)).thenReturn(review)
@@ -547,13 +569,14 @@ class ReviewServiceTest {
         `when`(menuPlainSummary.getRestaurantId()).thenReturn(1)
         `when`(menuPlainSummary.getCode()).thenReturn("MENU001")
 
-        val scoreCounts = listOf(
-            arrayOf<Any>(5, 10), // 점수 5: 10개
-            arrayOf<Any>(4, 5),  // 점수 4: 5개
-            arrayOf<Any>(3, 2),  // 점수 3: 2개
-            arrayOf<Any>(2, 1),  // 점수 2: 1개
-            arrayOf<Any>(1, 0)   // 점수 1: 0개
-        )
+        val scoreCounts =
+            listOf(
+                arrayOf<Any>(5, 10),
+                arrayOf<Any>(4, 5),
+                arrayOf<Any>(3, 2),
+                arrayOf<Any>(2, 1),
+                arrayOf<Any>(1, 0),
+            )
 
         `when`(menuRepository.findPlainMenuById(menuId.toString())).thenReturn(menuPlainSummary)
         `when`(reviewRepository.findScoreCountsByMenuId(1, "MENU001")).thenReturn(scoreCounts)

--- a/core/src/test/resources/data/v001.sql
+++ b/core/src/test/resources/data/v001.sql
@@ -12,6 +12,8 @@ DELETE FROM comment;
 DELETE FROM comment_like;
 DELETE FROM comment_report;
 DELETE FROM review;
+DELETE FROM keyword_review;
+DELETE FROM review_like;
 SET FOREIGN_KEY_CHECKS = 1;
 
 INSERT INTO `restaurant` (`id`, `code`, `name_kr`, `name_en`, `addr`, `lat`, `lng`, `etc`, `created_at`, `updated_at`)


### PR DESCRIPTION
## 변경사항
* 키워드 리뷰 추가를 위해 기존 리뷰 조회 쿼리 수정
* 리뷰 조회시 menuId가 아닌 restaurantId, code로 필터링
* 리뷰 저장 요청시 키워드 리뷰 관련 필드 추가
* 키워드 리뷰 관련 dist api 신규 생성
* 리뷰에 대한 좋아요 api 신규 생성
* 리뷰쪽 auth interceptor 처리 추가

## 참고
* 리뷰 또한 메뉴와 마찬가지로 userId 인증 이슈가 있습니다. 동일 api를 2개 생성하는 대신 QueryParam에 is_private flag를 붙여 true일 때만 로그인된 상태로 인식하여 유저 인증을 진행하고 아닐 경우 userId를 반드시 0으로 작성하도록 설정했습니다. 비로그인 상태에 대한 예외처리는 클라이언트에 넘기고, 로그인 상태에 대한 예외처리는 서버에서 처리하기 위해 해당 방식을 적용해보았습니다.
* 쿼리 실행 중 Timestamp, OffsetDateTime 충돌, Boolean 처리 불가 등의 이슈가 menu와 review 모두 존재하여 공통으로 쿼리 수정했습니다. pr 올리기 전 로컬테스트도 해보시는 걸 권장드립니다.
* KeywordReviewUtil은 각 string 키워드에 대한 메타 관리를 위해 int와 맵핑하여 설정했습니다. 더 나은 방향 있으시면 추후 수정하시면 됩니다.

## 추가로 개발되어야 하는 사항
* 메뉴에 대한 null 처리 -> 존재하지 않는 메뉴일 경우 500 에러 남
* 아이디가 다른 동일 메뉴에 대한 중복 리뷰 방지 -> menu_id가 다르면 동일 메뉴에 리뷰를 계속 작성 가능
* menuPlainSummary 받아올 때 Optional 처리