### PR TITLE
fix: swagger Failed to fetch 오류

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/SikshaApplication.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/SikshaApplication.kt
@@ -1,10 +1,15 @@
 package siksha.wafflestudio
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.servers.Server
 import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import java.util.TimeZone
 
+@OpenAPIDefinition(
+    servers = [Server(url = "/")],
+)
 @SpringBootApplication
 class SikshaApplication {
     @PostConstruct


### PR DESCRIPTION
swagger Failed to fetch 오류를 수정하였습니다. ([참고자료](https://github.com/springdoc/springdoc-openapi/issues/726)) 이건 로컬에서는 테스트가 안되어서 머지를 하고 해결이 안되면 다시 롤백하는 식으로 가야할 것 같네요.