### PR TITLE
fix: swagger network error

### DIFF
--- a/core/src/main/resources/application-core.yaml
+++ b/core/src/main/resources/application-core.yaml
@@ -15,6 +15,9 @@ spring:
   cache:
     type: redis
 
+server:
+  forward-headers-strategy: framework
+
 siksha:
   banned:
     words:


### PR DESCRIPTION
EKS 위에서 Ingress -> ELB가 http:// 로 traffic을 전달, swagger가 이걸 그대로 받아 api 서버를 http:// 로 노출
Springdoc이 X-Forwared-Proto 헤더를 보고, https:// 로 보게 변경

### 참고 (from GPT)
EKS 위에서 swagger가 `http://`로 잡히는 문제라면 **로드밸런서(ELB/ALB) + Ingress Controller** 때문에 Spring Boot가 실제 클라이언트 요청을 `https`로 인식하지 못하는 게 원인일 가능성이 큽니다.

---

## 🔎 원인 정리

* EKS Ingress → ALB/ELB가 SSL 종료(terminate) 후 백엔드 Pod(Spring)에는 `http://`로 트래픽 전달.
* Springdoc(OpenAPI)이 `X-Forwarded-Proto` 헤더를 보지 않아서, Swagger UI가 API 서버 주소를 `http://`로 노출.
* HTTPS 페이지에서 HTTP 요청을 보내니 브라우저가 Mixed Content로 막음 → `TypeError: NetworkError`.

---

## ✅ 해결 방법

### 1. Spring Boot에서 Forwarded 헤더 처리 활성화

`application.yml`:

```yaml
server:
  forward-headers-strategy: framework
```

(Spring Boot 2.6+ 에서는 `native` 대신 `framework` 권장)

또는 Bean 등록:

```kotlin
@Bean
fun forwardedHeaderFilter(): ForwardedHeaderFilter {
    return ForwardedHeaderFilter()
}
```

👉 이렇게 해야 Spring이 ALB가 넣어주는 `X-Forwarded-Proto: https` 를 인식하고 swagger URL도 `https://`로 잡습니다.

---

### 2. ALB Ingress Controller 확인

ALB Ingress는 기본적으로 `X-Forwarded-Proto` / `X-Forwarded-For` 헤더를 추가합니다.
따라서 별도 설정 없이 Spring이 읽을 수 있게만 해주면 충분합니다.

만약 Nginx Ingress를 쓰고 있다면, configmap에 다음을 추가해야 할 수 있습니다:

```yaml
proxy-set-headers: "ingress-nginx/custom-headers"
```

`custom-headers` ConfigMap에

```yaml
X-Forwarded-Proto: https
```

명시.

---

### 3. Swagger/OpenAPI에 강제로 `https` 서버 선언 (fallback)

```kotlin
@Bean
fun customOpenAPI(): OpenAPI {
    return OpenAPI()
        .servers(listOf(Server().url("https://your-domain.com")))
}
```

👉 최후 수단. 하지만 이 방식은 환경(dev/stg/prod)에 따라 따로 관리해야 해서 보통은 `forward-headers-strategy` 쪽으로 해결합니다.

---

## 📌 정리

* **EKS + ALB/Ingress 환경**이라면 → `server.forward-headers-strategy=framework` 설정 필수.
* 그래야 swagger가 `https://`로 API 호출 URL을 생성.
* 그래도 안되면 OpenAPI `servers()` 강제 지정.

---

혹시 지금 ingress가 **AWS ALB Ingress Controller**인지, **nginx ingress**인지 알려주실 수 있을까요? 그거에 따라 정확한 수정 포인트가 조금 달라집니다.
