### PR TITLE
fix: 메뉴 500 오류 수정

### DIFF
--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
@@ -61,7 +61,7 @@ data class MenuInListDto
                     score = menu.getScore(),
                     reviewCnt = menu.getReviewCnt(),
                     likeCnt = likeInfo?.getLikeCnt() ?: 0,
-                    isLiked = likeInfo?.getIsLiked() == true,
+                    isLiked = likeInfo?.getIsLiked() == 1,
                 )
             }
         }
@@ -218,7 +218,7 @@ data class MenuDetailsDto
                     etc = EtcUtils.convertMenuEtc(menu.getEtc()),
                     score = menu.getScore(),
                     reviewCnt = menu.getReviewCnt(),
-                    isLiked = likeInfo?.getIsLiked() == true,
+                    isLiked = likeInfo?.getIsLiked() == 1,
                     likeCnt = likeInfo?.getLikeCnt() ?: 0,
                 )
             }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/QueryDtos.kt
@@ -1,7 +1,7 @@
 package siksha.wafflestudio.core.domain.main.menu.dto
 
+import java.sql.Timestamp
 import java.time.LocalDate
-import java.time.OffsetDateTime
 
 interface MenuSummary {
     fun getId(): Int
@@ -22,9 +22,9 @@ interface MenuSummary {
 
     fun getEtc(): String?
 
-    fun getCreatedAt(): OffsetDateTime
+    fun getCreatedAt(): Timestamp
 
-    fun getUpdatedAt(): OffsetDateTime
+    fun getUpdatedAt(): Timestamp
 
     fun getScore(): Double?
 
@@ -44,7 +44,7 @@ interface MenuLikeSummary {
 
     fun getLikeCnt(): Int
 
-    fun getIsLiked(): Boolean
+    fun getIsLiked(): Int
 }
 
 interface MenuLikeCount {

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/review/service/ReviewService.kt
@@ -253,23 +253,7 @@ class ReviewService(
                 user.id.toString(),
             )
 
-        return MenuDetailsDto(
-            createdAt = menuSummary.getCreatedAt(),
-            updatedAt = menuSummary.getUpdatedAt(),
-            id = menuSummary.getId(),
-            restaurantId = menuSummary.getRestaurantId(),
-            code = menuSummary.getCode(),
-            date = menuSummary.getDate(),
-            type = menuSummary.getType(),
-            nameKr = menuSummary.getNameKr(),
-            nameEn = menuSummary.getNameEn(),
-            price = menuSummary.getPrice(),
-            etc = EtcUtils.convertMenuEtc(menuSummary.getEtc()),
-            score = menuSummary.getScore(),
-            reviewCnt = menuSummary.getReviewCnt(),
-            isLiked = menuLikeSummary.getIsLiked(),
-            likeCnt = menuLikeSummary.getLikeCnt(),
-        )
+        return MenuDetailsDto.from(menuSummary, menuLikeSummary)
     }
 
     @Transactional

--- a/core/src/test/kotlin/service/review/ReviewServiceTest.kt
+++ b/core/src/test/kotlin/service/review/ReviewServiceTest.kt
@@ -175,13 +175,13 @@ class ReviewServiceTest {
         `when`(menuSummary.getNameEn()).thenReturn("Test Menu")
         `when`(menuSummary.getPrice()).thenReturn(10000)
         `when`(menuSummary.getEtc()).thenReturn("[]")
-        `when`(menuSummary.getCreatedAt()).thenReturn(OffsetDateTime.now())
-        `when`(menuSummary.getUpdatedAt()).thenReturn(OffsetDateTime.now())
+        `when`(menuSummary.getCreatedAt()).thenReturn(Timestamp(System.currentTimeMillis()))
+        `when`(menuSummary.getUpdatedAt()).thenReturn(Timestamp(System.currentTimeMillis()))
         `when`(menuSummary.getScore()).thenReturn(4.5)
         `when`(menuSummary.getReviewCnt()).thenReturn(10)
 
         val menuLikeSummary = mock<MenuLikeSummary>()
-        `when`(menuLikeSummary.getIsLiked()).thenReturn(false)
+        `when`(menuLikeSummary.getIsLiked()).thenReturn(0)
         `when`(menuLikeSummary.getLikeCnt()).thenReturn(0)
 
         `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))


### PR DESCRIPTION
기존 `/menus/{menu_id}/like`, `/menus/{menu_id}/unlike`, `/menus/me` 에서 500 오류가 발생하였습니다. Dto에서 type이 맞지 않아 발생하는 문제라서 해당 부분을 수정하였습니다.