### PR TITLE
feat: alarm on/off api 추가

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/MenuController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/MenuController.kt
@@ -77,4 +77,22 @@ class MenuController(
             userId = request.userId,
         )
     }
+
+    @PostMapping("/{menu_id}/alarm/on")
+    fun menuAlarmOn(
+        @PathVariable("menu_id") menuId: Int,
+        request: HttpServletRequest,
+    ) = menuService.menuAlarmOn(
+        menuId = menuId,
+        userId = request.userId,
+    )
+
+    @PostMapping("/{menu_id}/alarm/off")
+    fun menuAlarmOff(
+        @PathVariable("menu_id") menuId: Int,
+        request: HttpServletRequest,
+    ) = menuService.menuAlarmOff(
+        menuId = menuId,
+        userId = request.userId,
+    )
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/common/exception/MainException.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/common/exception/MainException.kt
@@ -21,6 +21,8 @@ class MenuNotFoundException : MainException(HttpStatus.NOT_FOUND, "해당 메뉴
 
 class MenuLikeException : MainException(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 좋아요 처리 중에 오류가 발생했습니다.")
 
+class MenuNotLikedException : MainException(HttpStatus.NOT_FOUND, "해당 메뉴에 좋아요를 누르지 않았습니다.")
+
 class DuplicatedNicknameException : MainException(HttpStatus.CONFLICT, "중복된 닉네임이 존재합니다.")
 
 class BannedWordException : MainException(HttpStatus.BAD_REQUEST, "사용이 불가능한 단어가 포함되어 있습니다.")

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/MenuDtos.kt
@@ -259,4 +259,28 @@ data class MenuAlarmDto
         val isLiked: Boolean,
         @JsonProperty("alarm")
         val alarm: Boolean,
-    )
+    ) {
+        companion object {
+            fun from(
+                menu: MenuSummary,
+                isLiked: Int,
+                alarm: Boolean,
+            ): MenuAlarmDto {
+                return MenuAlarmDto(
+                    createdAt = menu.getCreatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
+                    updatedAt = menu.getUpdatedAt().toLocalDateTime().atOffset(ZoneOffset.UTC),
+                    id = menu.getId(),
+                    restaurantId = menu.getRestaurantId(),
+                    code = menu.getCode(),
+                    date = menu.getDate(),
+                    type = menu.getType(),
+                    nameKr = menu.getNameKr(),
+                    nameEn = menu.getNameEn(),
+                    price = menu.getPrice(),
+                    etc = EtcUtils.convertMenuEtc(menu.getEtc()),
+                    isLiked = isLiked == 1,
+                    alarm = alarm,
+                )
+            }
+        }
+    }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/MenuService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/MenuService.kt
@@ -82,7 +82,7 @@ class MenuService(
         val likeInfoMap = menuLikeSummaries.associateBy { it.getId() }
 
         // 모든 restaurant 정보 조회
-        val allRestaurants = restaurantRepository.findAll()
+        val allRestaurants = restaurantRepository.findAllByOrderByNameKr()
 
         // 날짜·타입별 기본 구조 초기화 (모든 식당, 빈 메뉴 리스트 포함)
         val dateGroupMap = mutableMapOf<LocalDate, MutableMap<String, MutableList<RestaurantInListDto>>>()

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/MenuService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/MenuService.kt
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import siksha.wafflestudio.core.domain.common.exception.MenuLikeException
 import siksha.wafflestudio.core.domain.common.exception.MenuNotFoundException
+import siksha.wafflestudio.core.domain.common.exception.MenuNotLikedException
 import siksha.wafflestudio.core.domain.main.menu.dto.DateWithTypeInListDto
+import siksha.wafflestudio.core.domain.main.menu.dto.MenuAlarmDto
 import siksha.wafflestudio.core.domain.main.menu.dto.MenuDetailsDto
 import siksha.wafflestudio.core.domain.main.menu.dto.MenuInListDto
 import siksha.wafflestudio.core.domain.main.menu.dto.MenuListResponseDto
@@ -255,5 +257,47 @@ class MenuService(
             count = result.size,
             result = result,
         )
+    }
+
+    @Transactional
+    fun menuAlarmOn(
+        menuId: Int,
+        userId: Int,
+    ): MenuAlarmDto {
+        val menuIdStr = menuId.toString()
+        val userIdStr = userId.toString()
+        val menu =
+            try {
+                menuRepository.findMenuById(menuIdStr)
+            } catch (e: EmptyResultDataAccessException) {
+                throw MenuNotFoundException()
+            }
+
+        val menuLike = menuRepository.findMenuLikeByMenuIdAndUserId(menuIdStr, userIdStr)
+        if (menuLike.getIsLiked() == 0) throw MenuNotLikedException()
+
+        // TODO: alarm 추가 로직
+        return MenuAlarmDto.from(menu, menuLike.getIsLiked(), true)
+    }
+
+    @Transactional
+    fun menuAlarmOff(
+        menuId: Int,
+        userId: Int,
+    ): MenuAlarmDto {
+        val menuIdStr = menuId.toString()
+        val userIdStr = userId.toString()
+        val menu =
+            try {
+                menuRepository.findMenuById(menuIdStr)
+            } catch (e: EmptyResultDataAccessException) {
+                throw MenuNotFoundException()
+            }
+
+        val menuLike = menuRepository.findMenuLikeByMenuIdAndUserId(menuIdStr, userIdStr)
+        if (menuLike.getIsLiked() == 0) throw MenuNotLikedException()
+
+        // TODO: alarm 해제 로직
+        return MenuAlarmDto.from(menu, menuLike.getIsLiked(), false)
     }
 }


### PR DESCRIPTION
 * Alarm on/off api를 추가하였습니다. 현재 실제로 알람 켜기/끄기 기능은 구현되어있지 않으며 일단 api만 만들어놓은 상태입니다.
 * 추가적으로 정책 논의 결과 레스토랑이 이름순으로 정렬되도록 수정하였습니다.