### PR TITLE
Feat/crawler api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mermaid
 mermaid_svg
 package-lock.json
 .codex
+.env.local

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/CrawlerController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/CrawlerController.kt
@@ -1,0 +1,27 @@
+package siksha.wafflestudio.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import siksha.wafflestudio.core.domain.main.meal.dto.CrawlerMealRequestDto
+import siksha.wafflestudio.core.domain.main.meal.usecase.SyncMealUseCase
+
+@RestController
+@Tag(name = "Crawler", description = "크롤러 데이터 수집 엔드포인트")
+class CrawlerController(
+    private val syncMealUseCase: SyncMealUseCase,
+) {
+    // POST /crawler/meals
+    @PostMapping("/crawler/meals")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "식단 동기화", description = "크롤러에서 수집한 식단 데이터를 V2 테이블에 동기화합니다.")
+    fun syncMeals(
+        @RequestBody request: CrawlerMealRequestDto,
+    ) {
+        syncMealUseCase(request)
+    }
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/data/MealMenuV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/data/MealMenuV2.kt
@@ -1,0 +1,34 @@
+package siksha.wafflestudio.core.domain.main.meal.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
+
+@Entity(name = "meal_menu_v2")
+@Table(
+    name = "meal_menu_v2",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["meal_id", "menu_id"]),
+    ],
+)
+class MealMenuV2(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_id", nullable = false)
+    val meal: MealV2,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    val menu: MenuV2,
+    @Column(nullable = false, length = 300)
+    val originalName: String,
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/data/MealV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/data/MealV2.kt
@@ -1,0 +1,46 @@
+package siksha.wafflestudio.core.domain.main.meal.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+@Entity(name = "meal_v2")
+@Table(name = "meal_v2")
+class MealV2(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    val restaurant: RestaurantV2,
+    @Column(nullable = false)
+    val date: LocalDate,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val type: MealType,
+    val price: Int? = null,
+    @Column(nullable = false)
+    val noMeat: Boolean = false,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)
+
+enum class MealType {
+    BREAKFAST,
+    LUNCH,
+    DINNER,
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/dto/CrawlerMealRequestDto.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/dto/CrawlerMealRequestDto.kt
@@ -1,0 +1,18 @@
+package siksha.wafflestudio.core.domain.main.meal.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import siksha.wafflestudio.core.domain.main.meal.data.MealType
+import java.time.LocalDate
+
+data class CrawlerMealRequestDto(
+    val restaurant: String,
+    val date: LocalDate,
+    val type: MealType,
+    val meals: List<MealItem>,
+) {
+    data class MealItem(
+        val price: Int? = null,
+        @JsonProperty("noMeat") val noMeat: Boolean = false,
+        val menus: List<String>,
+    )
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealMenuV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealMenuV2Repository.kt
@@ -1,0 +1,6 @@
+package siksha.wafflestudio.core.domain.main.meal.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.meal.data.MealMenuV2
+
+interface MealMenuV2Repository : JpaRepository<MealMenuV2, Long>

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealV2Repository.kt
@@ -1,0 +1,11 @@
+package siksha.wafflestudio.core.domain.main.meal.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.meal.data.MealType
+import siksha.wafflestudio.core.domain.main.meal.data.MealV2
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import java.time.LocalDate
+
+interface MealV2Repository : JpaRepository<MealV2, Long> {
+    fun deleteAllByRestaurantAndDateAndType(restaurant: RestaurantV2, date: LocalDate, type: MealType)
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/repository/MealV2Repository.kt
@@ -7,5 +7,9 @@ import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
 import java.time.LocalDate
 
 interface MealV2Repository : JpaRepository<MealV2, Long> {
-    fun deleteAllByRestaurantAndDateAndType(restaurant: RestaurantV2, date: LocalDate, type: MealType)
+    fun deleteAllByRestaurantAndDateAndType(
+        restaurant: RestaurantV2,
+        date: LocalDate,
+        type: MealType,
+    )
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
@@ -1,0 +1,33 @@
+package siksha.wafflestudio.core.domain.main.meal.usecase
+
+import org.springframework.stereotype.Component
+import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
+import siksha.wafflestudio.core.domain.main.menu.repository.MenuAliasV2Repository
+import siksha.wafflestudio.core.domain.main.menu.repository.MenuV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+
+/**
+ * 크롤링 원본 메뉴명을 정규화된 MenuV2 entity로 변환
+ * 현재는 stub 구현으로, alias 매핑이 있으면 사용하고 없으면 원본명 그대로 사용
+ * 추후 메뉴명 정규화 로직(LLM, fuzzy matching 등)이 이 UseCase 내부에서 구현될 예정
+ */
+@Component
+class NormalizeMenuUseCase(
+    private val menuAliasV2Repository: MenuAliasV2Repository,
+    private val menuV2Repository: MenuV2Repository,
+) {
+    operator fun invoke(
+        originalName: String,
+        restaurant: RestaurantV2,
+    ): MenuV2 {
+        val normalizedName = menuAliasV2Repository.findByAlias(originalName)?.menuName ?: originalName
+
+        return menuV2Repository.findByRestaurantAndName(restaurant, normalizedName)
+            ?: menuV2Repository.save(
+                MenuV2(
+                    restaurant = restaurant,
+                    name = normalizedName,
+                ),
+            )
+    }
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/SyncMealUseCase.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/SyncMealUseCase.kt
@@ -1,0 +1,50 @@
+package siksha.wafflestudio.core.domain.main.meal.usecase
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import siksha.wafflestudio.core.domain.common.exception.RestaurantNotFound
+import siksha.wafflestudio.core.domain.main.meal.data.MealMenuV2
+import siksha.wafflestudio.core.domain.main.meal.data.MealV2
+import siksha.wafflestudio.core.domain.main.meal.dto.CrawlerMealRequestDto
+import siksha.wafflestudio.core.domain.main.meal.repository.MealMenuV2Repository
+import siksha.wafflestudio.core.domain.main.meal.repository.MealV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantV2Repository
+
+@Component
+class SyncMealUseCase(
+    private val restaurantV2Repository: RestaurantV2Repository,
+    private val mealV2Repository: MealV2Repository,
+    private val mealMenuV2Repository: MealMenuV2Repository,
+    private val normalizeMenuUseCase: NormalizeMenuUseCase,
+) {
+    @Transactional
+    operator fun invoke(request: CrawlerMealRequestDto) {
+        val restaurant = restaurantV2Repository.findByName(request.restaurant) ?: throw RestaurantNotFound()
+
+        mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, request.date, request.type)
+
+        request.meals.forEach { mealItem ->
+            val meal =
+                mealV2Repository.save(
+                    MealV2(
+                        restaurant = restaurant,
+                        date = request.date,
+                        type = request.type,
+                        price = mealItem.price,
+                        noMeat = mealItem.noMeat,
+                    ),
+                )
+
+            mealItem.menus.forEach { originalName ->
+                val menu = normalizeMenuUseCase(originalName, restaurant)
+                mealMenuV2Repository.save(
+                    MealMenuV2(
+                        meal = meal,
+                        menu = menu,
+                        originalName = originalName,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/data/MenuAliasV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/data/MenuAliasV2.kt
@@ -1,0 +1,26 @@
+package siksha.wafflestudio.core.domain.main.menu.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+@Entity(name = "menu_alias_v2")
+@Table(name = "menu_alias_v2")
+class MenuAliasV2(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @Column(nullable = false, unique = true, length = 300)
+    val alias: String,
+    @Column(nullable = false, length = 200)
+    val menuName: String,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/data/MenuV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/data/MenuV2.kt
@@ -1,0 +1,37 @@
+package siksha.wafflestudio.core.domain.main.menu.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+@Entity(name = "menu_v2")
+@Table(
+    name = "menu_v2",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["restaurant_id", "name"]),
+    ],
+)
+class MenuV2(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    val restaurant: RestaurantV2,
+    @Column(nullable = false, length = 200)
+    val name: String,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuAliasV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuAliasV2Repository.kt
@@ -1,0 +1,8 @@
+package siksha.wafflestudio.core.domain.main.menu.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.menu.data.MenuAliasV2
+
+interface MenuAliasV2Repository : JpaRepository<MenuAliasV2, Long> {
+    fun findByAlias(alias: String): MenuAliasV2?
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuV2Repository.kt
@@ -5,5 +5,8 @@ import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
 import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
 
 interface MenuV2Repository : JpaRepository<MenuV2, Long> {
-    fun findByRestaurantAndName(restaurant: RestaurantV2, name: String): MenuV2?
+    fun findByRestaurantAndName(
+        restaurant: RestaurantV2,
+        name: String,
+    ): MenuV2?
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/repository/MenuV2Repository.kt
@@ -1,0 +1,9 @@
+package siksha.wafflestudio.core.domain.main.menu.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+
+interface MenuV2Repository : JpaRepository<MenuV2, Long> {
+    fun findByRestaurantAndName(restaurant: RestaurantV2, name: String): MenuV2?
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantV2.kt
@@ -1,0 +1,41 @@
+package siksha.wafflestudio.core.domain.main.restaurant.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+@Entity(name = "restaurant_v2")
+@Table(name = "restaurant_v2")
+class RestaurantV2(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @Column(nullable = false, unique = true, length = 100)
+    val name: String,
+    @Column(length = 50)
+    val building: String? = null,
+    @Column(length = 200)
+    val address: String? = null,
+    @Column(precision = 10, scale = 7)
+    val latitude: BigDecimal? = null,
+    @Column(precision = 10, scale = 7)
+    val longitude: BigDecimal? = null,
+    @Column(columnDefinition = "json")
+    val operatingHours: String? = null,
+    @Column(name = "owner_id")
+    val ownerId: Int? = null,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+    @UpdateTimestamp
+    @Column(nullable = false)
+    val updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantV2Repository.kt
@@ -1,0 +1,8 @@
+package siksha.wafflestudio.core.domain.main.restaurant.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+
+interface RestaurantV2Repository : JpaRepository<RestaurantV2, Long> {
+    fun findByName(name: String): RestaurantV2?
+}

--- a/core/src/test/kotlin/usecase/meal/SyncMealUseCaseTest.kt
+++ b/core/src/test/kotlin/usecase/meal/SyncMealUseCaseTest.kt
@@ -1,0 +1,231 @@
+package siksha.wafflestudio.core.usecase.meal
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import siksha.wafflestudio.core.domain.common.exception.RestaurantNotFound
+import siksha.wafflestudio.core.domain.main.meal.data.MealMenuV2
+import siksha.wafflestudio.core.domain.main.meal.data.MealType
+import siksha.wafflestudio.core.domain.main.meal.data.MealV2
+import siksha.wafflestudio.core.domain.main.meal.dto.CrawlerMealRequestDto
+import siksha.wafflestudio.core.domain.main.meal.repository.MealMenuV2Repository
+import siksha.wafflestudio.core.domain.main.meal.repository.MealV2Repository
+import siksha.wafflestudio.core.domain.main.meal.usecase.NormalizeMenuUseCase
+import siksha.wafflestudio.core.domain.main.meal.usecase.SyncMealUseCase
+import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantV2Repository
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+class SyncMealUseCaseTest {
+    private lateinit var restaurantV2Repository: RestaurantV2Repository
+    private lateinit var mealV2Repository: MealV2Repository
+    private lateinit var mealMenuV2Repository: MealMenuV2Repository
+    private lateinit var normalizeMenuUseCase: NormalizeMenuUseCase
+    private lateinit var useCase: SyncMealUseCase
+
+    @BeforeEach
+    internal fun setUp() {
+        restaurantV2Repository = mockk()
+        mealV2Repository = mockk()
+        mealMenuV2Repository = mockk()
+        normalizeMenuUseCase = mockk()
+        useCase =
+            SyncMealUseCase(
+                restaurantV2Repository,
+                mealV2Repository,
+                mealMenuV2Repository,
+                normalizeMenuUseCase,
+            )
+        clearAllMocks()
+    }
+
+    @Test
+    fun `restaurant가 존재하지 않으면 RestaurantNotFound 던짐`() {
+        // given
+        every { restaurantV2Repository.findByName("없는식당") } returns null
+
+        // when & then
+        val request =
+            CrawlerMealRequestDto(
+                restaurant = "없는식당",
+                date = LocalDate.of(2026, 4, 1),
+                type = MealType.LUNCH,
+                meals =
+                    listOf(
+                        CrawlerMealRequestDto.MealItem(
+                            price = 1000,
+                            noMeat = false,
+                            menus = listOf("아무거나"),
+                        ),
+                    ),
+            )
+        assertThrows<RestaurantNotFound> { useCase(request) }
+
+        // verify
+        verify { restaurantV2Repository.findByName("없는식당") }
+        verify(exactly = 0) { mealV2Repository.deleteAllByRestaurantAndDateAndType(any(), any(), any()) }
+        verify(exactly = 0) { mealV2Repository.save(any()) }
+    }
+
+    @Test
+    fun `정상 흐름 - 단일 meal과 단일 menu 동기화`() {
+        // given
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val date = LocalDate.of(2026, 4, 1)
+        val type = MealType.LUNCH
+        val savedMeal = MealV2(id = 100, restaurant = restaurant, date = date, type = type, price = 12000, noMeat = false)
+        val normalizedMenu = MenuV2(id = 10, restaurant = restaurant, name = "뚝배기순두부")
+
+        every { restaurantV2Repository.findByName("자하연식당 3층") } returns restaurant
+        every { mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, date, type) } just runs
+        every { mealV2Repository.save(any()) } returns savedMeal
+        every { normalizeMenuUseCase.invoke("뚝배기순두부", restaurant) } returns normalizedMenu
+        every { mealMenuV2Repository.save(any()) } answers { firstArg() }
+
+        // when
+        val request =
+            CrawlerMealRequestDto(
+                restaurant = "자하연식당 3층",
+                date = date,
+                type = type,
+                meals =
+                    listOf(
+                        CrawlerMealRequestDto.MealItem(
+                            price = 12000,
+                            noMeat = false,
+                            menus = listOf("뚝배기순두부"),
+                        ),
+                    ),
+            )
+        useCase(request)
+
+        // then
+        verify { restaurantV2Repository.findByName("자하연식당 3층") }
+        verify { mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, date, type) }
+        verify(exactly = 1) { mealV2Repository.save(any()) }
+        verify(exactly = 1) { normalizeMenuUseCase.invoke("뚝배기순두부", restaurant) }
+        verify(exactly = 1) { mealMenuV2Repository.save(any()) }
+    }
+
+    @Test
+    fun `정상 흐름 - 여러 meal과 묶음 메뉴 동기화`() {
+        // given
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val date = LocalDate.of(2026, 4, 1)
+        val type = MealType.LUNCH
+        val savedMeal = MealV2(id = 100, restaurant = restaurant, date = date, type = type)
+        val menuChicken = MenuV2(id = 1, restaurant = restaurant, name = "닭갈비")
+        val menuSalad = MenuV2(id = 2, restaurant = restaurant, name = "그린샐러드")
+        val menuSoup = MenuV2(id = 3, restaurant = restaurant, name = "열무된장국")
+
+        every { restaurantV2Repository.findByName("자하연식당 3층") } returns restaurant
+        every { mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, date, type) } just runs
+        every { mealV2Repository.save(any()) } returns savedMeal
+        every { normalizeMenuUseCase.invoke("닭갈비", restaurant) } returns menuChicken
+        every { normalizeMenuUseCase.invoke("그린샐러드", restaurant) } returns menuSalad
+        every { normalizeMenuUseCase.invoke("열무된장국", restaurant) } returns menuSoup
+        every { mealMenuV2Repository.save(any()) } answers { firstArg() }
+
+        // when
+        val request =
+            CrawlerMealRequestDto(
+                restaurant = "자하연식당 3층",
+                date = date,
+                type = type,
+                meals =
+                    listOf(
+                        CrawlerMealRequestDto.MealItem(
+                            price = 12000,
+                            noMeat = false,
+                            menus = listOf("닭갈비"),
+                        ),
+                        CrawlerMealRequestDto.MealItem(
+                            price = 7000,
+                            noMeat = false,
+                            menus = listOf("그린샐러드", "열무된장국"),
+                        ),
+                    ),
+            )
+        useCase(request)
+
+        // then
+        verify(exactly = 2) { mealV2Repository.save(any()) }
+        verify(exactly = 3) { normalizeMenuUseCase.invoke(any(), restaurant) }
+        verify(exactly = 3) { mealMenuV2Repository.save(any()) }
+    }
+
+    @Test
+    fun `meal_menu_v2에 original_name이 정확히 저장됨`() {
+        // given
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val date = LocalDate.of(2026, 4, 1)
+        val type = MealType.LUNCH
+        val savedMeal = MealV2(id = 100, restaurant = restaurant, date = date, type = type)
+        val normalizedMenu = MenuV2(id = 10, restaurant = restaurant, name = "치즈돈까스")
+        val mealMenuSlot = slot<MealMenuV2>()
+
+        every { restaurantV2Repository.findByName(any()) } returns restaurant
+        every { mealV2Repository.deleteAllByRestaurantAndDateAndType(any(), any(), any()) } just runs
+        every { mealV2Repository.save(any()) } returns savedMeal
+        every { normalizeMenuUseCase.invoke(any(), restaurant) } returns normalizedMenu
+        every { mealMenuV2Repository.save(capture(mealMenuSlot)) } answers { firstArg() }
+
+        // when
+        val request =
+            CrawlerMealRequestDto(
+                restaurant = "자하연식당 3층",
+                date = date,
+                type = type,
+                meals =
+                    listOf(
+                        CrawlerMealRequestDto.MealItem(
+                            price = 5000,
+                            noMeat = false,
+                            menus = listOf("치즈 돈까스"),
+                        ),
+                    ),
+            )
+        useCase(request)
+
+        // then
+        assertEquals("치즈 돈까스", mealMenuSlot.captured.originalName)
+        assertEquals("치즈돈까스", mealMenuSlot.captured.menu.name)
+        assertEquals(savedMeal, mealMenuSlot.captured.meal)
+    }
+
+    @Test
+    fun `meals가 빈 배열이면 delete만 수행하고 새로 저장하지 않음`() {
+        // given
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val date = LocalDate.of(2026, 4, 1)
+        val type = MealType.LUNCH
+
+        every { restaurantV2Repository.findByName("자하연식당 3층") } returns restaurant
+        every { mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, date, type) } just runs
+
+        // when
+        val request =
+            CrawlerMealRequestDto(
+                restaurant = "자하연식당 3층",
+                date = date,
+                type = type,
+                meals = emptyList(),
+            )
+        useCase(request)
+
+        // then
+        verify { mealV2Repository.deleteAllByRestaurantAndDateAndType(restaurant, date, type) }
+        verify(exactly = 0) { mealV2Repository.save(any()) }
+        verify(exactly = 0) { mealMenuV2Repository.save(any()) }
+        verify(exactly = 0) { normalizeMenuUseCase.invoke(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
  - DB 개편(V2 스키마)에 맞춘 크롤러 → 서버 식단 동기화 API 추가
  - `POST /crawler/meals` 엔드포인트 신설
  - UseCase 패턴 적용: 정규화 로직(`NormalizeMenuUseCase`)을 별도 컴포넌트로 분리하여 병렬 개발 가능

  ## 변경 사항
  ### V2 entity / repository
  - `RestaurantV2`, `MenuV2`, `MenuAliasV2`, `MealV2`, `MealMenuV2` entity 및 각 repository

  ### 크롤러 API
  - `CrawlerController` (`POST /crawler/meals`)
  - `SyncMealUseCase` — 동기화 흐름 조율 (restaurant 조회 → 기존 meal 삭제 → meal/meal_menu 생성)
  - `NormalizeMenuUseCase` — 메뉴 정규화 (현재 stub, 한경님이 구현 예정)
  - `CrawlerMealRequestDto`

  ### 테스트
  - `SyncMealUseCaseTest` — 5개 케이스 (정상 흐름, restaurant not found, 묶음 메뉴, original_name 검증, 빈 meals)

  ## 남은 이슈 (별도 작업)
  - [ ] `NormalizeMenuUseCase` 실제 정규화 로직 구현 + `menu_alias_v2` 동적 insert
  - [x] 현재 인증 처링 없음.