### PR TITLE
feat : 크롤러 API 인증을 위한 API Key 필터 추가

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilter.kt
@@ -1,0 +1,41 @@
+package siksha.wafflestudio.api.common
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+import siksha.wafflestudio.core.domain.common.exception.UnauthorizedUserException
+
+@Component
+class CrawlerApiKeyFilter(
+    @Value("\${siksha.crawler.api-key:}") private val expectedApiKey: String,
+    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
+) : OncePerRequestFilter() {
+    companion object {
+        private const val HDR_API_KEY = "X-API-Key"
+        private const val CRAWLER_PATH_PREFIX = "/crawler/"
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        chain: FilterChain,
+    ) {
+        if (!request.requestURI.startsWith(CRAWLER_PATH_PREFIX)) {
+            chain.doFilter(request, response)
+            return
+        }
+
+        val apiKey = request.getHeader(HDR_API_KEY)
+        if (apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
+            resolver.resolveException(request, response, null, UnauthorizedUserException())
+            return
+        }
+
+        chain.doFilter(request, response)
+    }
+}

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
@@ -48,6 +48,7 @@ class JwtAuthenticationFilter(
             AntPathRequestMatcher("/reviews/keyword/dist"),
             AntPathRequestMatcher("/voc"),
             AntPathRequestMatcher("/ping"),
+            AntPathRequestMatcher("/crawler/**"),
         )
 
     override fun doFilterInternal(

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
@@ -24,6 +24,7 @@ private typealias AuthorizationRegistry = AuthorizeHttpRequestsConfigurer<HttpSe
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val crawlerApiKeyFilter: CrawlerApiKeyFilter,
     @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
 ) {
     @Bean
@@ -36,6 +37,7 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { configureAuthorization(it) }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(crawlerApiKeyFilter, JwtAuthenticationFilter::class.java)
             .exceptionHandling { configureExceptionHandling(it) }
             .build()
 
@@ -66,6 +68,7 @@ class SecurityConfig(
                 "/versions/**",
                 "/voc",
                 "/ping",
+                "/crawler/**",
             ).permitAll()
             .anyRequest()
             .authenticated()

--- a/core/src/main/resources/application-core.yaml
+++ b/core/src/main/resources/application-core.yaml
@@ -27,6 +27,8 @@ siksha:
     words:
   firebase:
     service-account:
+  crawler:
+    api-key:
 
 oci:
   vault:


### PR DESCRIPTION
## Summary
  - 크롤러 → 서버 API(`/crawler/**`) 호출 시 `X-API-Key` 헤더 검증 필터 추가
  - service-to-service 통신이라 JWT 대신 API Key 방식 채택
  - 기존 JWT 인증 흐름은 그대로 유지, 크롤러 경로만 API Key 검증으로 분기

  ## 변경 사항
  ### 신규
  - `CrawlerApiKeyFilter` — `/crawler/**` 경로의 `X-API-Key` 헤더 검증

  ### 수정
  - `SecurityConfig` — 신규 필터 등록 + `/crawler/**` permitAll 추가
  - `JwtAuthenticationFilter` — `permitAllMatchers`에 `/crawler/**` 추가 (JWT 검증 skip)
  - `application-core.yaml` — `siksha.crawler.api-key` 설정 항목 추가