### PR TITLE
festival api 추가

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
@@ -49,6 +49,7 @@ class JwtAuthenticationFilter(
             AntPathRequestMatcher("/voc"),
             AntPathRequestMatcher("/ping"),
             AntPathRequestMatcher("/crawler/**"),
+            AntPathRequestMatcher("/festival/**"),
         )
 
     override fun doFilterInternal(

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
@@ -69,6 +69,7 @@ class SecurityConfig(
                 "/voc",
                 "/ping",
                 "/crawler/**",
+                "/festival/**",
             ).permitAll()
             .anyRequest()
             .authenticated()

--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/FestivalController.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/FestivalController.kt
@@ -1,0 +1,36 @@
+package siksha.wafflestudio.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import siksha.wafflestudio.core.domain.main.menu.dto.FestivalDatesResponseDto
+import siksha.wafflestudio.core.domain.main.menu.dto.IsFestivalResponseDto
+import siksha.wafflestudio.core.domain.main.menu.service.FestivalService
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/festival")
+@Tag(name = "Festival", description = "축제 일정 조회 엔드포인트")
+class FestivalController(
+    private val festivalService: FestivalService,
+) {
+    // GET /festival/dates
+    @GetMapping("/dates")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "축제 일정 조회", description = "축제 기간에 해당하는 날짜 목록을 조회합니다")
+    fun getFestival(): FestivalDatesResponseDto = festivalService.getFestival()
+
+    // GET /festival/{input_date}
+    @GetMapping("/{input_date}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "축제 여부 조회", description = "특정 날짜가 축제 기간에 해당하는지 조회합니다")
+    fun getIsFestivalWhereDate(
+        @PathVariable("input_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) inputDate: LocalDate,
+    ): IsFestivalResponseDto = festivalService.getIsFestivalWhereDate(inputDate)
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/FestivalDtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/dto/FestivalDtos.kt
@@ -1,0 +1,27 @@
+package siksha.wafflestudio.core.domain.main.menu.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.time.LocalDate
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class FestivalDatesResponseDto
+    @JsonCreator
+    constructor(
+        @JsonProperty("festival_dates")
+        val festivalDates: List<LocalDate>,
+    )
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class IsFestivalResponseDto
+    @JsonCreator
+    constructor(
+        @JsonProperty("target_date")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        val targetDate: LocalDate,
+        @JsonProperty("is_festival")
+        val isFestival: Boolean,
+    )

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/FestivalService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/FestivalService.kt
@@ -1,0 +1,23 @@
+package siksha.wafflestudio.core.domain.main.menu.service
+
+import org.springframework.stereotype.Service
+import siksha.wafflestudio.core.domain.main.menu.dto.FestivalDatesResponseDto
+import siksha.wafflestudio.core.domain.main.menu.dto.IsFestivalResponseDto
+import java.time.LocalDate
+
+@Service
+class FestivalService {
+    private val festivalDates: List<LocalDate> =
+        listOf(
+            LocalDate.of(2026, 5, 12),
+            LocalDate.of(2026, 5, 13),
+        )
+
+    fun getFestival(): FestivalDatesResponseDto = FestivalDatesResponseDto(festivalDates = festivalDates)
+
+    fun getIsFestivalWhereDate(inputDate: LocalDate): IsFestivalResponseDto =
+        IsFestivalResponseDto(
+            targetDate = inputDate,
+            isFestival = inputDate in festivalDates,
+        )
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/FestivalService.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/menu/service/FestivalService.kt
@@ -11,6 +11,7 @@ class FestivalService {
         listOf(
             LocalDate.of(2026, 5, 12),
             LocalDate.of(2026, 5, 13),
+            LocalDate.of(2026, 5, 14),
         )
 
     fun getFestival(): FestivalDatesResponseDto = FestivalDatesResponseDto(festivalDates = festivalDates)

--- a/core/src/test/kotlin/service/menu/FestivalServiceTest.kt
+++ b/core/src/test/kotlin/service/menu/FestivalServiceTest.kt
@@ -24,6 +24,7 @@ class FestivalServiceTest {
             listOf(
                 LocalDate.of(2026, 5, 12),
                 LocalDate.of(2026, 5, 13),
+                LocalDate.of(2026, 5, 14),
             ),
             result.festivalDates,
         )

--- a/core/src/test/kotlin/service/menu/FestivalServiceTest.kt
+++ b/core/src/test/kotlin/service/menu/FestivalServiceTest.kt
@@ -1,0 +1,47 @@
+package siksha.wafflestudio.core.service.menu
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import siksha.wafflestudio.core.domain.main.menu.service.FestivalService
+import java.time.LocalDate
+
+class FestivalServiceTest {
+    private lateinit var service: FestivalService
+
+    @BeforeEach
+    internal fun setUp() {
+        service = FestivalService()
+    }
+
+    @Test
+    fun `return all festival dates`() {
+        val result = service.getFestival()
+
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 5, 12),
+                LocalDate.of(2026, 5, 13),
+            ),
+            result.festivalDates,
+        )
+    }
+
+    @Test
+    fun `return true when input date is festival`() {
+        val result = service.getIsFestivalWhereDate(LocalDate.of(2026, 5, 12))
+
+        assertEquals(LocalDate.of(2026, 5, 12), result.targetDate)
+        assertTrue(result.isFestival)
+    }
+
+    @Test
+    fun `return false when input date is not festival`() {
+        val result = service.getIsFestivalWhereDate(LocalDate.of(2026, 5, 11))
+
+        assertEquals(LocalDate.of(2026, 5, 11), result.targetDate)
+        assertFalse(result.isFestival)
+    }
+}


### PR DESCRIPTION
  ## Summary
  - 축제 일정 조회용 엔드포인트 2종 추가 (`GET /festival/dates`, `GET /festival/{input_date}`)
  - 비로그인 접근 가능
  - 축제 날짜 `2026-05-12`, `2026-05-13`, `2026-05-14` 하드코딩