### PR TITLE
feat : NormalizeMenuUseCase 메뉴명 정규화 로직 추가

### DIFF
--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
@@ -16,7 +16,8 @@ class NormalizeMenuUseCase(
         originalName: String,
         restaurant: RestaurantV2,
     ): MenuV2 {
-        val normalizedName = menuAliasV2Repository.findByAlias(originalName)?.menuName ?: normalizeName(originalName)
+        val alias = menuAliasV2Repository.findByAlias(originalName)
+        val normalizedName = alias?.menuName ?: normalizeName(originalName)
 
         val menu =
             menuV2Repository.findByRestaurantAndName(restaurant, normalizedName)
@@ -27,7 +28,7 @@ class NormalizeMenuUseCase(
                     ),
                 )
 
-        if (originalName != menu.name && menuAliasV2Repository.findByAlias(originalName) == null) {
+        if (alias == null && originalName != menu.name) {
             menuAliasV2Repository.save(
                 MenuAliasV2(
                     alias = originalName,

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/meal/usecase/NormalizeMenuUseCase.kt
@@ -1,16 +1,12 @@
 package siksha.wafflestudio.core.domain.main.meal.usecase
 
 import org.springframework.stereotype.Component
+import siksha.wafflestudio.core.domain.main.menu.data.MenuAliasV2
 import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
 import siksha.wafflestudio.core.domain.main.menu.repository.MenuAliasV2Repository
 import siksha.wafflestudio.core.domain.main.menu.repository.MenuV2Repository
 import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
 
-/**
- * 크롤링 원본 메뉴명을 정규화된 MenuV2 entity로 변환
- * 현재는 stub 구현으로, alias 매핑이 있으면 사용하고 없으면 원본명 그대로 사용
- * 추후 메뉴명 정규화 로직(LLM, fuzzy matching 등)이 이 UseCase 내부에서 구현될 예정
- */
 @Component
 class NormalizeMenuUseCase(
     private val menuAliasV2Repository: MenuAliasV2Repository,
@@ -20,14 +16,48 @@ class NormalizeMenuUseCase(
         originalName: String,
         restaurant: RestaurantV2,
     ): MenuV2 {
-        val normalizedName = menuAliasV2Repository.findByAlias(originalName)?.menuName ?: originalName
+        val normalizedName = menuAliasV2Repository.findByAlias(originalName)?.menuName ?: normalizeName(originalName)
 
-        return menuV2Repository.findByRestaurantAndName(restaurant, normalizedName)
-            ?: menuV2Repository.save(
-                MenuV2(
-                    restaurant = restaurant,
-                    name = normalizedName,
+        val menu =
+            menuV2Repository.findByRestaurantAndName(restaurant, normalizedName)
+                ?: menuV2Repository.save(
+                    MenuV2(
+                        restaurant = restaurant,
+                        name = normalizedName,
+                    ),
+                )
+
+        if (originalName != menu.name && menuAliasV2Repository.findByAlias(originalName) == null) {
+            menuAliasV2Repository.save(
+                MenuAliasV2(
+                    alias = originalName,
+                    menuName = menu.name,
                 ),
             )
+        }
+
+        return menu
+    }
+
+    private fun normalizeName(name: String): String {
+        var normalized = name.trim()
+        normalized = normalized.replace(OPERATING_PARENTHESIS_REGEX, " ")
+        normalized = normalized.replace(DELIMITER_REGEX, " ")
+        normalized = normalized.replace(OPERATING_TOKEN_REGEX, " ")
+        normalized = normalized.replace(DESCRIPTIVE_TOKEN_REGEX, " ")
+        normalized = normalized.replace(MULTIPLE_SPACES_REGEX, " ").trim()
+        normalized = normalized.replace(SPACES_REGEX, "")
+
+        return normalized.ifBlank { name.trim() }
+    }
+
+    companion object {
+        private val OPERATING_PARENTHESIS_REGEX = Regex("""\((HOT|NEW|추천|특식|한정|셀프|추가|별도)[^)]*\)""")
+        private val DELIMITER_REGEX = Regex("""[\/,|]+""")
+        private val OPERATING_TOKEN_REGEX = Regex("""\b(HOT|NEW|추천|특식|한정|셀프|추가|별도)\b""")
+        private val DESCRIPTIVE_TOKEN_REGEX =
+            Regex("""(원산지[^\s]*|알레르기[^\s]*|소스\s*별도|밥\s*/?\s*김치\s*포함|밥\s*포함|김치\s*포함)""")
+        private val MULTIPLE_SPACES_REGEX = Regex("""\s+""")
+        private val SPACES_REGEX = Regex("""\s+""")
     }
 }

--- a/core/src/test/kotlin/usecase/meal/NormalizeMenuUseCaseTest.kt
+++ b/core/src/test/kotlin/usecase/meal/NormalizeMenuUseCaseTest.kt
@@ -1,0 +1,90 @@
+package siksha.wafflestudio.core.usecase.meal
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import siksha.wafflestudio.core.domain.main.meal.usecase.NormalizeMenuUseCase
+import siksha.wafflestudio.core.domain.main.menu.data.MenuAliasV2
+import siksha.wafflestudio.core.domain.main.menu.data.MenuV2
+import siksha.wafflestudio.core.domain.main.menu.repository.MenuAliasV2Repository
+import siksha.wafflestudio.core.domain.main.menu.repository.MenuV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import kotlin.test.assertEquals
+
+class NormalizeMenuUseCaseTest {
+    private lateinit var menuAliasV2Repository: MenuAliasV2Repository
+    private lateinit var menuV2Repository: MenuV2Repository
+    private lateinit var useCase: NormalizeMenuUseCase
+
+    @BeforeEach
+    internal fun setUp() {
+        menuAliasV2Repository = mockk()
+        menuV2Repository = mockk()
+        useCase = NormalizeMenuUseCase(menuAliasV2Repository, menuV2Repository)
+        clearAllMocks()
+    }
+
+    @Test
+    fun `alias exact hit이면 alias menu name으로 menu 조회 후 반환`() {
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val alias = MenuAliasV2(id = 1, alias = "치즈 돈까스", menuName = "치즈돈까스")
+        val menu = MenuV2(id = 10, restaurant = restaurant, name = "치즈돈까스")
+
+        every { menuAliasV2Repository.findByAlias("치즈 돈까스") } returns alias
+        every { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") } returns menu
+
+        val result = useCase("치즈 돈까스", restaurant)
+
+        assertEquals(menu, result)
+        verify(exactly = 2) { menuAliasV2Repository.findByAlias("치즈 돈까스") }
+        verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") }
+        verify(exactly = 0) { menuAliasV2Repository.save(any()) }
+        verify(exactly = 0) { menuV2Repository.save(any()) }
+    }
+
+    @Test
+    fun `alias miss이면 정규화된 menu 이름으로 기존 menu를 조회하고 alias를 저장한다`() {
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val menu = MenuV2(id = 10, restaurant = restaurant, name = "치즈돈까스")
+        val aliasSlot = slot<MenuAliasV2>()
+
+        every { menuAliasV2Repository.findByAlias("추천 치즈 돈까스 (추천)") } returns null
+        every { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") } returns menu
+        every { menuAliasV2Repository.save(capture(aliasSlot)) } answers { firstArg() }
+
+        val result = useCase("추천 치즈 돈까스 (추천)", restaurant)
+
+        assertEquals(menu, result)
+        assertEquals("추천 치즈 돈까스 (추천)", aliasSlot.captured.alias)
+        assertEquals("치즈돈까스", aliasSlot.captured.menuName)
+        verify(exactly = 2) { menuAliasV2Repository.findByAlias("추천 치즈 돈까스 (추천)") }
+        verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") }
+        verify(exactly = 0) { menuV2Repository.save(any()) }
+    }
+
+    @Test
+    fun `기존 menu가 없으면 정규화된 이름으로 새 menu를 만들고 alias를 저장한다`() {
+        val restaurant = RestaurantV2(id = 1, name = "자하연식당 3층")
+        val createdMenu = MenuV2(id = 10, restaurant = restaurant, name = "김치찌개")
+        val menuSlot = slot<MenuV2>()
+        val aliasSlot = slot<MenuAliasV2>()
+
+        every { menuAliasV2Repository.findByAlias("HOT 김치찌개 / 밥 포함") } returns null
+        every { menuV2Repository.findByRestaurantAndName(restaurant, "김치찌개") } returns null
+        every { menuV2Repository.save(capture(menuSlot)) } returns createdMenu
+        every { menuAliasV2Repository.save(capture(aliasSlot)) } answers { firstArg() }
+
+        val result = useCase("HOT 김치찌개 / 밥 포함", restaurant)
+
+        assertEquals(createdMenu, result)
+        assertEquals("김치찌개", menuSlot.captured.name)
+        assertEquals("HOT 김치찌개 / 밥 포함", aliasSlot.captured.alias)
+        assertEquals("김치찌개", aliasSlot.captured.menuName)
+        verify(exactly = 2) { menuAliasV2Repository.findByAlias("HOT 김치찌개 / 밥 포함") }
+        verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "김치찌개") }
+    }
+}

--- a/core/src/test/kotlin/usecase/meal/NormalizeMenuUseCaseTest.kt
+++ b/core/src/test/kotlin/usecase/meal/NormalizeMenuUseCaseTest.kt
@@ -40,7 +40,7 @@ class NormalizeMenuUseCaseTest {
         val result = useCase("치즈 돈까스", restaurant)
 
         assertEquals(menu, result)
-        verify(exactly = 2) { menuAliasV2Repository.findByAlias("치즈 돈까스") }
+        verify(exactly = 1) { menuAliasV2Repository.findByAlias("치즈 돈까스") }
         verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") }
         verify(exactly = 0) { menuAliasV2Repository.save(any()) }
         verify(exactly = 0) { menuV2Repository.save(any()) }
@@ -61,7 +61,7 @@ class NormalizeMenuUseCaseTest {
         assertEquals(menu, result)
         assertEquals("추천 치즈 돈까스 (추천)", aliasSlot.captured.alias)
         assertEquals("치즈돈까스", aliasSlot.captured.menuName)
-        verify(exactly = 2) { menuAliasV2Repository.findByAlias("추천 치즈 돈까스 (추천)") }
+        verify(exactly = 1) { menuAliasV2Repository.findByAlias("추천 치즈 돈까스 (추천)") }
         verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "치즈돈까스") }
         verify(exactly = 0) { menuV2Repository.save(any()) }
     }
@@ -84,7 +84,7 @@ class NormalizeMenuUseCaseTest {
         assertEquals("김치찌개", menuSlot.captured.name)
         assertEquals("HOT 김치찌개 / 밥 포함", aliasSlot.captured.alias)
         assertEquals("김치찌개", aliasSlot.captured.menuName)
-        verify(exactly = 2) { menuAliasV2Repository.findByAlias("HOT 김치찌개 / 밥 포함") }
+        verify(exactly = 1) { menuAliasV2Repository.findByAlias("HOT 김치찌개 / 밥 포함") }
         verify(exactly = 1) { menuV2Repository.findByRestaurantAndName(restaurant, "김치찌개") }
     }
 }


### PR DESCRIPTION
## Summary
- 크롤링 원본 메뉴명을 내부 정규화 이름으로 변환하는 `NormalizeMenuUseCase` 구현
- `menu_v2.name`은 사용자 노출용이 아닌 정규화된 메뉴명으로 저장하도록 정리
- alias miss 시 rule-based 정규화 후 `menu_v2` 조회/생성, `menu_alias_v2` 자동 적재 로직 추가

## 변경 사항
### 신규
- `NormalizeMenuUseCase` 정규화 로직 구현
- 원본 메뉴명 기준 alias miss 시 `menu_alias_v2` 자동 저장 로직 추가

### 수정
- `NormalizeMenuUseCaseTest` — 현재 정규화 흐름에 맞게 테스트 정리
- 운영성 토큰/설명성 문구 제거 케이스 검증 추가

## 참고
- 현재는 LLM, vector search, 사전 정의된 메뉴 pool 없이 rule-based 정규화만 적용
- 사용자에게는 `meal_menu_v2.original_name`을 노출하고, `menu_v2.name`은 내부 정규화된 값으로 활용