### PR TITLE
RestaurantCustom의 like column에 백틱 추가

### DIFF
--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantCustom.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantCustom.kt
@@ -36,7 +36,7 @@ data class RestaurantCustom(
     @JoinColumn(name = "restaurant_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     var restaurant: Restaurant,
-    @Column(name = "like", nullable = false)
+    @Column(name = "`like`", nullable = false)
     var like: Boolean = false,
     @Column(name = "visible", nullable = false)
     var visible: Boolean = true,


### PR DESCRIPTION
#129 를 통해 이미 존재하는 레코드를 update하는 경우에는 에러가 발생하지 않게 되었으나, 새로운 레코드를 추가하는 경우 에러가 발생
RestaurantCustom 클래스의 like 칼럼에 백틱 처리를 하지 않을 시 like가 SQL 명령어로 인식되어 발생하는 문제로 파악하여 백틱 추가