### PR TITLE
v2 restaurant 구현

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/controller/RestaurantV2Controller.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/controller/RestaurantV2Controller.kt
@@ -1,0 +1,64 @@
+package siksha.wafflestudio.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import siksha.wafflestudio.api.common.userId
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2LikeRequestDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2LikeResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2ListResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderUpdateRequestDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderUpdateResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2VisibleRequestDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2VisibleResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.service.RestaurantV2Service
+
+@RestController
+@RequestMapping("/v2/restaurants")
+@Tag(name = "Restaurants-V2", description = "식당 정보 관리 엔드포인트 V2")
+class RestaurantV2Controller(
+    private val restaurantService: RestaurantV2Service,
+) {
+    @GetMapping("")
+    @Operation(summary = "식당 목록 조회", description = "모든 식당 목록을 조회합니다")
+    fun getRestaurants(): RestaurantV2ListResponseDto = restaurantService.getAllRestaurants()
+
+    @GetMapping("/personal")
+    @Operation(summary = "식당 목록 + 즐겨찾기, 순서 정렬에 따른 개인화된 응답 (로그인)", description = "개인화된 식당 목록을 조회합니다 (로그인)")
+    fun getPersonalizedRestaurants(request: HttpServletRequest): RestaurantV2ListResponseDto =
+        restaurantService.getAllPersonalizedRestaurants(request.userId)
+
+    @PatchMapping("/like/{restaurantId}")
+    @Operation(summary = "식당 좋아요 누르기/취소", description = "특정 식당을 좋아요하거나 취소합니다")
+    fun setRestaurantLike(
+        request: HttpServletRequest,
+        @PathVariable restaurantId: Int,
+        @RequestBody requestBody: RestaurantV2LikeRequestDto,
+    ): RestaurantV2LikeResponseDto = restaurantService.setRestaurantLike(request.userId, restaurantId, requestBody.like)
+
+    @PatchMapping("/visible/{restaurantId}")
+    @Operation(summary = "식당 보이기/숨기기", description = "특정 식당을 보이거나 숨깁니다")
+    fun setRestaurantVisible(
+        request: HttpServletRequest,
+        @PathVariable restaurantId: Int,
+        @RequestBody requestBody: RestaurantV2VisibleRequestDto,
+    ): RestaurantV2VisibleResponseDto = restaurantService.setRestaurantVisible(request.userId, restaurantId, requestBody.visible)
+
+    @GetMapping("/order")
+    @Operation(summary = "식당 순서 조회", description = "식당의 순서를 조회합니다")
+    fun getRestaurantOrder(request: HttpServletRequest): RestaurantV2OrderResponseDto = restaurantService.getRestaurantOrder(request.userId)
+
+    @PatchMapping("/order")
+    @Operation(summary = "식당 순서 변경", description = "식당의 순서를 변경합니다")
+    fun changeRestaurantOrder(
+        request: HttpServletRequest,
+        @RequestBody requestBody: RestaurantV2OrderUpdateRequestDto,
+    ): RestaurantV2OrderUpdateResponseDto = restaurantService.changeRestaurantOrder(request.userId, requestBody)
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantCustomV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantCustomV2.kt
@@ -1,0 +1,51 @@
+package siksha.wafflestudio.core.domain.main.restaurant.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.UpdateTimestamp
+import siksha.wafflestudio.core.domain.user.data.User
+import java.io.Serializable
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+class RestaurantCustomV2Pk(
+    var user: Int = 0,
+    var restaurant: Int = 0,
+) : Serializable
+
+@Entity(name = "restaurant_custom_v2")
+@Table(name = "restaurant_custom_v2")
+@IdClass(RestaurantCustomV2Pk::class)
+data class RestaurantCustomV2(
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    var user: User,
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    var restaurant: RestaurantV2,
+    @Column(name = "`like`", nullable = false)
+    var like: Boolean = false,
+    @Column(name = "visible", nullable = false)
+    var visible: Boolean = true,
+    @Column(name = "order_index")
+    var orderIndex: Int? = null,
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+    @UpdateTimestamp
+    @Column(nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneId.of("UTC")),
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantV2.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/data/RestaurantV2.kt
@@ -17,7 +17,7 @@ import java.time.ZoneId
 class RestaurantV2(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0,
+    val id: Int = 0,
     @Column(nullable = false, unique = true, length = 100)
     val name: String,
     @Column(length = 50)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/dto/RestaurantV2Dtos.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/dto/RestaurantV2Dtos.kt
@@ -1,0 +1,122 @@
+package siksha.wafflestudio.core.domain.main.restaurant.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import siksha.wafflestudio.core.util.EtcUtils
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2ResponseDto
+    @JsonCreator
+    constructor(
+        @JsonProperty("id")
+        val id: Int = 0,
+        @JsonProperty("code")
+        val code: String?,
+        @JsonProperty("nameKr")
+        val nameKr: String?,
+        @JsonProperty("nameEn")
+        val nameEn: String?,
+        @JsonProperty("building")
+        val building: String?,
+        @JsonProperty("addr")
+        val addr: String?,
+        @JsonProperty("lat")
+        val lat: BigDecimal?,
+        @JsonProperty("lng")
+        val lng: BigDecimal?,
+        @JsonProperty("liked")
+        val liked: Boolean?,
+        @JsonProperty("visible")
+        val visible: Boolean?,
+        @JsonProperty("operatingHours")
+        val operatingHours: JsonNode,
+        @JsonProperty("ownerId")
+        val ownerId: Int?,
+        @JsonProperty("created_at")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
+        val createdAt: OffsetDateTime,
+        @JsonProperty("updated_at")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
+        val updatedAt: OffsetDateTime,
+    ) {
+        companion object {
+            fun from(
+                restaurant: RestaurantV2,
+                liked: Boolean = false,
+                visible: Boolean = true,
+            ): RestaurantV2ResponseDto =
+                RestaurantV2ResponseDto(
+                    id = restaurant.id,
+                    code = restaurant.name,
+                    nameKr = restaurant.name,
+                    nameEn = null,
+                    building = restaurant.building,
+                    addr = restaurant.address,
+                    liked = liked,
+                    visible = visible,
+                    lat = restaurant.latitude,
+                    lng = restaurant.longitude,
+                    operatingHours = EtcUtils.convertEtc(restaurant.operatingHours),
+                    ownerId = restaurant.ownerId,
+                    createdAt = restaurant.createdAt,
+                    updatedAt = restaurant.updatedAt,
+                )
+        }
+    }
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2ListResponseDto(
+    val count: Int,
+    val result: List<RestaurantV2ResponseDto>,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2LikeResponseDto(
+    @field:JsonProperty("id")
+    val restaurantId: Int,
+    val liked: Boolean,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2LikeRequestDto(
+    @field:JsonProperty("like")
+    val like: Boolean,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2VisibleResponseDto(
+    @field:JsonProperty("id")
+    val restaurantId: Int,
+    val visible: Boolean,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2VisibleRequestDto(
+    @field:JsonProperty("visible")
+    val visible: Boolean,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2OrderResponseDto(
+    @field:JsonProperty("order")
+    val restaurantOrder: List<Int>,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2OrderUpdateResponseDto(
+    @field:JsonProperty("order")
+    val order: List<Int>,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class RestaurantV2OrderUpdateRequestDto(
+    @field:JsonProperty("order")
+    val order: List<Int>,
+)

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantCustomV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantCustomV2Repository.kt
@@ -1,0 +1,14 @@
+package siksha.wafflestudio.core.domain.main.restaurant.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantCustomV2
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantCustomV2Pk
+
+interface RestaurantCustomV2Repository : JpaRepository<RestaurantCustomV2, RestaurantCustomV2Pk> {
+    fun findRestaurantCustomV2ByUserIdAndRestaurantId(
+        userId: Int,
+        restaurantId: Int,
+    ): RestaurantCustomV2?
+
+    fun findAllByUserId(userId: Int): List<RestaurantCustomV2>
+}

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantV2Repository.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/repository/RestaurantV2Repository.kt
@@ -3,6 +3,6 @@ package siksha.wafflestudio.core.domain.main.restaurant.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
 
-interface RestaurantV2Repository : JpaRepository<RestaurantV2, Long> {
+interface RestaurantV2Repository : JpaRepository<RestaurantV2, Int> {
     fun findByName(name: String): RestaurantV2?
 }

--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/service/RestaurantV2Service.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/main/restaurant/service/RestaurantV2Service.kt
@@ -1,0 +1,178 @@
+package siksha.wafflestudio.core.domain.main.restaurant.service
+
+import jakarta.transaction.Transactional
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import siksha.wafflestudio.core.domain.common.exception.RestaurantNotFoundException
+import siksha.wafflestudio.core.domain.common.exception.UserNotFoundException
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantCustomV2
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2LikeResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2ListResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderUpdateRequestDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2OrderUpdateResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2ResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.dto.RestaurantV2VisibleResponseDto
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantCustomV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantV2Repository
+import siksha.wafflestudio.core.domain.user.repository.UserRepository
+
+@Service
+class RestaurantV2Service(
+    private val restaurantRepository: RestaurantV2Repository,
+    private val userRepository: UserRepository,
+    private val restaurantCustomRepository: RestaurantCustomV2Repository,
+) {
+    @Cacheable(value = ["restaurantCache"])
+    fun getAllRestaurants(): RestaurantV2ListResponseDto {
+        val restaurants = restaurantRepository.findAll()
+        return RestaurantV2ListResponseDto(
+            count = restaurants.size,
+            result =
+                restaurants.map { restaurant ->
+                    RestaurantV2ResponseDto.from(restaurant)
+                },
+        )
+    }
+
+    fun getAllPersonalizedRestaurants(userId: Int): RestaurantV2ListResponseDto {
+        val restaurants = restaurantRepository.findAll()
+        val customs = restaurantCustomRepository.findAllByUserId(userId)
+        val customMap = customs.associateBy { it.restaurant.id }
+
+        val (orderedRestaurants, unorderedRestaurants) =
+            restaurants
+                .partition {
+                    customMap[it.id]?.orderIndex != null
+                }.let { (ordered, unordered) ->
+                    ordered.sortedBy { customMap[it.id]!!.orderIndex!! } to unordered
+                }
+
+        val resultRestaurants = orderedRestaurants + unorderedRestaurants
+
+        return RestaurantV2ListResponseDto(
+            count = resultRestaurants.size,
+            result =
+                resultRestaurants.map { restaurant ->
+                    val custom = customMap[restaurant.id]
+                    val liked = custom?.like ?: false
+                    val visible = custom?.visible ?: true
+                    RestaurantV2ResponseDto.from(restaurant, liked, visible)
+                },
+        )
+    }
+
+    @Transactional
+    fun setRestaurantLike(
+        userId: Int,
+        restaurantId: Int,
+        like: Boolean,
+    ): RestaurantV2LikeResponseDto {
+        val restaurant =
+            restaurantRepository
+                .findById(restaurantId)
+                .orElseThrow { RestaurantNotFoundException() }
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { UserNotFoundException() }
+
+        val custom =
+            restaurantCustomRepository.findRestaurantCustomV2ByUserIdAndRestaurantId(userId, restaurant.id)
+                ?: RestaurantCustomV2(user = user, restaurant = restaurant)
+
+        custom.like = like
+        val savedCustom = restaurantCustomRepository.save(custom)
+
+        return RestaurantV2LikeResponseDto(
+            restaurantId = restaurantId,
+            liked = savedCustom.like,
+        )
+    }
+
+    @Transactional
+    fun setRestaurantVisible(
+        userId: Int,
+        restaurantId: Int,
+        visible: Boolean,
+    ): RestaurantV2VisibleResponseDto {
+        val restaurant =
+            restaurantRepository
+                .findById(restaurantId)
+                .orElseThrow { RestaurantNotFoundException() }
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { UserNotFoundException() }
+
+        val custom =
+            restaurantCustomRepository.findRestaurantCustomV2ByUserIdAndRestaurantId(userId, restaurant.id)
+                ?: RestaurantCustomV2(user = user, restaurant = restaurant)
+
+        custom.visible = visible
+        val savedCustom = restaurantCustomRepository.save(custom)
+
+        return RestaurantV2VisibleResponseDto(
+            restaurantId = restaurantId,
+            visible = savedCustom.visible,
+        )
+    }
+
+    fun getRestaurantOrder(userId: Int): RestaurantV2OrderResponseDto {
+        val orderedCustoms =
+            restaurantCustomRepository
+                .findAllByUserId(userId)
+                .filter { it.orderIndex != null }
+                .sortedBy { it.orderIndex }
+
+        return RestaurantV2OrderResponseDto(
+            restaurantOrder = orderedCustoms.map { it.restaurant.id },
+        )
+    }
+
+    @Transactional
+    fun changeRestaurantOrder(
+        userId: Int,
+        request: RestaurantV2OrderUpdateRequestDto,
+    ): RestaurantV2OrderUpdateResponseDto {
+        val user = userRepository.findById(userId).orElseThrow { UserNotFoundException() }
+        val requestedOrderIds = request.order
+
+        val restaurantMap =
+            restaurantRepository
+                .findAllById(requestedOrderIds)
+                .associateBy { it.id }
+
+        if (restaurantMap.size != requestedOrderIds.toSet().size) {
+            throw RestaurantNotFoundException()
+        }
+
+        val existingCustoms = restaurantCustomRepository.findAllByUserId(userId)
+        val customMap = existingCustoms.associateBy { it.restaurant.id }
+
+        val customsToSave = mutableListOf<RestaurantCustomV2>()
+
+        existingCustoms
+            .filter { it.orderIndex != null && it.restaurant.id !in requestedOrderIds }
+            .forEach { custom ->
+                custom.orderIndex = null
+                customsToSave.add(custom)
+            }
+
+        requestedOrderIds.forEachIndexed { index, restaurantId ->
+            val newOrderIndex = index + 1
+            val custom = customMap[restaurantId] ?: RestaurantCustomV2(user = user, restaurant = restaurantMap[restaurantId]!!)
+
+            if (custom.orderIndex != newOrderIndex) {
+                custom.orderIndex = newOrderIndex
+                customsToSave.add(custom)
+            }
+        }
+
+        if (customsToSave.isNotEmpty()) {
+            restaurantCustomRepository.saveAll(customsToSave)
+        }
+
+        return RestaurantV2OrderUpdateResponseDto(requestedOrderIds)
+    }
+}

--- a/core/src/main/resources/db/migration/V7__fix_restaurant_v2_table.sql
+++ b/core/src/main/resources/db/migration/V7__fix_restaurant_v2_table.sql
@@ -1,0 +1,45 @@
+START TRANSACTION;
+
+ALTER TABLE menu_v2
+    DROP FOREIGN KEY fk_menu_v2_restaurant;
+ALTER TABLE meal_v2
+    DROP FOREIGN KEY fk_meal_v2_restaurant;
+
+ALTER TABLE restaurant_v2
+    MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE menu_v2
+    MODIFY COLUMN restaurant_id INT NOT NULL COMMENT '메뉴가 속한 식당/코너 ID';
+ALTER TABLE meal_v2
+    MODIFY COLUMN restaurant_id INT NOT NULL COMMENT '식단이 제공되는 식당/코너 ID';
+
+ALTER TABLE menu_v2
+    ADD CONSTRAINT fk_menu_v2_restaurant
+    FOREIGN KEY (restaurant_id) REFERENCES restaurant_v2 (id)
+    ON DELETE RESTRICT;
+ALTER TABLE meal_v2
+    ADD CONSTRAINT fk_meal_v2_restaurant
+    FOREIGN KEY (restaurant_id) REFERENCES restaurant_v2 (id)
+    ON DELETE RESTRICT;
+
+create table if not exists restaurant_custom_v2
+(
+    user_id       int                                 not null comment '사용자 ID',
+    restaurant_id int                                 not null comment '식당 ID',
+    `like`        tinyint(1)                          not null default 0 comment '좋아요 여부',
+    visible       tinyint(1)                          not null default 1 comment '노출 여부',
+    order_index   int                                 null comment '사용자 지정 정렬 순서',
+    created_at    timestamp default CURRENT_TIMESTAMP not null comment '생성 시간',
+    updated_at    timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '변경 시간',
+    primary key (user_id, restaurant_id),
+    constraint restaurant_custom_v2_user_fk
+        foreign key (user_id) references user (id)
+            on delete cascade,
+    constraint restaurant_custom_v2_restaurant_fk
+        foreign key (restaurant_id) references restaurant_v2 (id)
+            on delete cascade
+) engine = InnoDB
+  default charset = utf8mb4
+  collate = utf8mb4_unicode_ci;
+
+COMMIT;

--- a/core/src/test/kotlin/service/restaurant/RestaurantV2ServiceTest.kt
+++ b/core/src/test/kotlin/service/restaurant/RestaurantV2ServiceTest.kt
@@ -1,0 +1,56 @@
+package service.restaurant
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import siksha.wafflestudio.core.domain.main.restaurant.data.RestaurantV2
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantCustomV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.repository.RestaurantV2Repository
+import siksha.wafflestudio.core.domain.main.restaurant.service.RestaurantV2Service
+import siksha.wafflestudio.core.domain.user.repository.UserRepository
+import java.math.BigDecimal
+import kotlin.test.assertNotNull
+
+class RestaurantV2ServiceTest {
+    private lateinit var restaurantRepository: RestaurantV2Repository
+    private lateinit var userRepository: UserRepository
+    private lateinit var restaurantCustomRepository: RestaurantCustomV2Repository
+    private lateinit var service: RestaurantV2Service
+
+    @BeforeEach
+    internal fun setUp() {
+        clearAllMocks()
+        restaurantRepository = mockk()
+        userRepository = mockk()
+        restaurantCustomRepository = mockk()
+        service = RestaurantV2Service(restaurantRepository, userRepository, restaurantCustomRepository)
+    }
+
+    @Test
+    fun `get restaurants`() {
+        // given
+        val restaurant =
+            RestaurantV2(
+                id = 1,
+                name = "test",
+                building = "test",
+                address = "test",
+                latitude = BigDecimal(0.0),
+                longitude = BigDecimal(0.0),
+                operatingHours = null,
+                ownerId = null
+            )
+        every { restaurantRepository.findAll() } returns listOf(restaurant)
+
+        // when
+        val result = service.getAllRestaurants()
+
+        // then
+        assertNotNull(result)
+        Assertions.assertEquals(result.result.size, result.count)
+        Assertions.assertEquals(1, result.result[0].id)
+    }
+}

--- a/core/src/test/kotlin/service/restaurant/RestaurantV2ServiceTest.kt
+++ b/core/src/test/kotlin/service/restaurant/RestaurantV2ServiceTest.kt
@@ -41,7 +41,7 @@ class RestaurantV2ServiceTest {
                 latitude = BigDecimal(0.0),
                 longitude = BigDecimal(0.0),
                 operatingHours = null,
-                ownerId = null
+                ownerId = null,
             )
         every { restaurantRepository.findAll() } returns listOf(restaurant)
 


### PR DESCRIPTION
- 기존 `/restaurants` API에 맞추어 `/v2/restaurants` API 구현
- restaurant.id type을 bigint에서 int로 변경, restaurant_custom_v2 생성
- RestaurantResponseDto의 etc를 RestaurantV2ResponseDto의 operatingHours로 변경, building, ownerId 추가, 나머지는 기존 유지