### PR TITLE
fix: align jdbc timezone with application timezone

### DIFF
--- a/core/src/main/resources/application-core.yaml
+++ b/core/src/main/resources/application-core.yaml
@@ -4,8 +4,10 @@ spring:
       ddl-auto: validate
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
-      jdbc:
-        time_zone: UTC
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
     show-sql: true
   flyway:
     enabled: true


### PR DESCRIPTION
## Summary
- Pass Hibernate JDBC timezone through the supported spring.jpa.properties path
- Align JDBC date binding with the application default timezone, Asia/Seoul

## Why
Crawler v2 payloads sent with LocalDate values were being persisted one day earlier in MySQL DATE columns after the app sets the JVM timezone to Asia/Seoul. This blocks safe v2 crawler backfills.

## Validation
- ./gradlew ktlintCheck
- Verified on dev before the fix that a 2026-12-31 crawler payload persisted as 2026-12-30, so backfill is paused until this PR is deployed.