### PR TITLE
fix: preserve hibernate jdbc timezone property key

### DIFF
--- a/core/src/main/resources/application-core.yaml
+++ b/core/src/main/resources/application-core.yaml
@@ -5,9 +5,7 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     properties:
-      hibernate:
-        jdbc:
-          time_zone: Asia/Seoul
+      "[hibernate.jdbc.time_zone]": Asia/Seoul
     show-sql: true
   flyway:
     enabled: true


### PR DESCRIPTION
## Summary
- Use bracket notation for the Hibernate JDBC timezone property key so Spring preserves hibernate.jdbc.time_zone exactly

## Why
A crawler v2 payload with date 2026-05-22 is still persisted as 2026-05-21 on dev. A JDBC probe showed that UTC Calendar DATE binding reproduces this shift, while plain/KST DATE binding preserves the date. The previous nested YAML key did not change the runtime behavior, so this change passes the exact Hibernate property key.

## Validation
- ./gradlew ktlintCheck
- Dev verification before this fix: POST /v2/crawler/meals returned 201 but inserted the meal under the previous day; the bad test row was removed.