### PR TITLE
fix: version API 요청 예시를 snake_case로 표시

### DIFF
--- a/core/src/main/kotlin/siksha/wafflestudio/core/domain/v1/version/dto/VersionUpdateRequestDto.kt
+++ b/core/src/main/kotlin/siksha/wafflestudio/core/domain/v1/version/dto/VersionUpdateRequestDto.kt
@@ -1,8 +1,11 @@
 package siksha.wafflestudio.core.domain.v1.version.dto
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class VersionUpdateRequestDto(
     @field:Pattern(
         regexp = "^[0-9]+\\.[0-9]+\\.[0-9]+$",

--- a/core/src/test/kotlin/dto/version/VersionUpdateRequestDtoTest.kt
+++ b/core/src/test/kotlin/dto/version/VersionUpdateRequestDtoTest.kt
@@ -1,0 +1,24 @@
+package dto.version
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import siksha.wafflestudio.core.domain.v1.version.dto.VersionUpdateRequestDto
+
+class VersionUpdateRequestDtoTest {
+    private val objectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `use snake case for version update request json`() {
+        val request = objectMapper.readValue<VersionUpdateRequestDto>("""{"minimum_version":"3.5.1"}""")
+
+        assertEquals("3.5.1", request.minimumVersion)
+
+        val json = objectMapper.valueToTree<JsonNode>(request)
+        assertEquals("3.5.1", json["minimum_version"].asText())
+        assertFalse(json.has("minimumVersion"))
+    }
+}


### PR DESCRIPTION
## 변경 사항

- `VersionUpdateRequestDto`에 snake_case naming strategy를 명시했습니다.
- Swagger/OpenAPI request body가 `minimumVersion` 대신 `minimum_version`으로 표시됩니다.
- 실제 JSON 역직렬화와 직렬화도 `minimum_version` 계약을 사용하도록 회귀 테스트를 추가했습니다.

```json
{
  "minimum_version": "3.5.1"
}
```

## 검증

- [x] `./gradlew :core:test --tests dto.version.VersionUpdateRequestDtoTest`
- [x] 관련 version service 및 API 테스트
- [x] `./gradlew :core:ktlintCheck`
- [x] `./gradlew :api:bootJar`