### PR TITLE
fix: version 조회 API 비로그인 호출 허용

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
@@ -52,7 +52,8 @@ class JwtAuthenticationFilter(
             AntPathRequestMatcher("/voc"),
             AntPathRequestMatcher("/ping"),
             AntPathRequestMatcher("/v2/crawler/**"),
-            AntPathRequestMatcher("/versions/**"),
+            AntPathRequestMatcher("/versions/**", HttpMethod.GET.name()),
+            AntPathRequestMatcher("/versions/**", HttpMethod.PATCH.name()),
             AntPathRequestMatcher("/menus/festival/**"),
         )
 

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
@@ -45,7 +45,13 @@ class SecurityConfig(
         auth
             .requestMatchers(HttpMethod.OPTIONS, "/**")
             .permitAll()
-            .requestMatchers(HttpMethod.GET, "/community/boards", "/community/boards/{board_id}")
+            .requestMatchers(
+                HttpMethod.GET,
+                "/community/boards",
+                "/community/boards/{board_id}",
+                "/versions/**",
+            ).permitAll()
+            .requestMatchers(HttpMethod.PATCH, "/versions/**")
             .permitAll()
             .requestMatchers(
                 AntPathRequestMatcher.antMatcher("/community/**/web"),
@@ -68,7 +74,6 @@ class SecurityConfig(
                 "/reviews/keyword/dist",
                 "/v2/reviews/dist",
                 "/v2/reviews/keyword/dist",
-                "/versions/**",
                 "/voc",
                 "/ping",
                 "/v2/crawler/**",

--- a/api/src/test/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilterTest.kt
@@ -15,7 +15,22 @@ class JwtAuthenticationFilterTest {
     private val filter = JwtAuthenticationFilter(jwtProvider, resolver)
 
     @Test
-    fun `allow version endpoints without jwt because api key filter owns update authentication`() {
+    fun `allow version lookup without jwt`() {
+        val request =
+            MockHttpServletRequest("GET", "/versions/IOS").apply {
+                servletPath = "/versions/IOS"
+            }
+        val response = MockHttpServletResponse()
+        val chain = mockk<FilterChain>(relaxed = true)
+
+        filter.doFilter(request, response, chain)
+
+        verify(exactly = 0) { resolver.resolveException(any(), any(), any(), any()) }
+        verify(exactly = 1) { chain.doFilter(request, response) }
+    }
+
+    @Test
+    fun `allow version update without jwt because api key filter owns update authentication`() {
         val request =
             MockHttpServletRequest("PATCH", "/versions/IOS").apply {
                 servletPath = "/versions/IOS"
@@ -27,5 +42,20 @@ class JwtAuthenticationFilterTest {
 
         verify(exactly = 0) { resolver.resolveException(any(), any(), any(), any()) }
         verify(exactly = 1) { chain.doFilter(request, response) }
+    }
+
+    @Test
+    fun `reject unsupported version method without jwt`() {
+        val request =
+            MockHttpServletRequest("DELETE", "/versions/IOS").apply {
+                servletPath = "/versions/IOS"
+            }
+        val response = MockHttpServletResponse()
+        val chain = mockk<FilterChain>(relaxed = true)
+
+        filter.doFilter(request, response, chain)
+
+        verify(exactly = 1) { resolver.resolveException(request, response, null, any()) }
+        verify(exactly = 0) { chain.doFilter(any(), any()) }
     }
 }


### PR DESCRIPTION
## 변경 사항

- `GET /versions/{clientType}`를 JWT 없이 호출할 수 있도록 명시적으로 허용했습니다.
- `PATCH /versions/{clientType}`는 JWT 필터를 건너뛰되 기존 crawler `X-API-Key` 인증을 계속 적용합니다.
- 기존 `/versions/**` 전체 허용을 GET/PATCH method 단위로 축소해, 그 외 method가 인증 필터를 우회하지 못하도록 했습니다.
- GET 공개, PATCH 인증 위임, 미지원 method 거부에 대한 회귀 테스트를 추가했습니다.

## 보안 경계

| Method | 인증 |
|---|---|
| GET | 비로그인 허용 |
| PATCH | `X-API-Key` 필요 |
| 기타 | JWT 필요 |

## 검증

- [x] `./gradlew :api:test`
- [x] `./gradlew :api:ktlintCheck`
- [x] `./gradlew :api:bootJar`