### PR TITLE
refactor: 인증 필터 구조 단순화

### DIFF
--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilter.kt
@@ -17,9 +17,16 @@ class CrawlerApiKeyFilter(
     @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
 ) : OncePerRequestFilter() {
     companion object {
-        private const val HDR_API_KEY = "X-API-Key"
+        private const val API_KEY = "X-API-Key"
         private const val CRAWLER_PATH_PREFIX = "/v2/crawler/"
         private const val VERSION_PATH_PREFIX = "/versions/"
+
+        internal fun requiresApiKey(request: HttpServletRequest): Boolean =
+            request.requestURI.startsWith(CRAWLER_PATH_PREFIX) ||
+                (
+                    request.method.equals(HttpMethod.PATCH.name(), ignoreCase = true) &&
+                        request.requestURI.startsWith(VERSION_PATH_PREFIX)
+                )
     }
 
     override fun doFilterInternal(
@@ -27,12 +34,12 @@ class CrawlerApiKeyFilter(
         response: HttpServletResponse,
         chain: FilterChain,
     ) {
-        if (!requiresCrawlerApiKey(request)) {
+        if (!requiresApiKey(request)) {
             chain.doFilter(request, response)
             return
         }
 
-        val apiKey = request.getHeader(HDR_API_KEY)
+        val apiKey = request.getHeader(API_KEY)
         if (apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
             resolver.resolveException(request, response, null, UnauthorizedUserException())
             return
@@ -40,11 +47,4 @@ class CrawlerApiKeyFilter(
 
         chain.doFilter(request, response)
     }
-
-    private fun requiresCrawlerApiKey(request: HttpServletRequest): Boolean =
-        request.requestURI.startsWith(CRAWLER_PATH_PREFIX) ||
-            (
-                request.method.equals(HttpMethod.PATCH.name(), ignoreCase = true) &&
-                    request.requestURI.startsWith(VERSION_PATH_PREFIX)
-            )
 }

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilter.kt
@@ -5,9 +5,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpMethod
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -15,87 +12,75 @@ import org.springframework.web.servlet.HandlerExceptionResolver
 import siksha.wafflestudio.core.domain.auth.JwtProvider
 import siksha.wafflestudio.core.domain.common.exception.auth.UnauthorizedUserException
 
+private const val USER_ID = "userId"
+private const val AUTHORIZATION = "Authorization"
+private const val BEARER_PREFIX = "Bearer "
+
 @Component
 class JwtAuthenticationFilter(
     private val jwtProvider: JwtProvider,
     @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
 ) : OncePerRequestFilter() {
     companion object {
-        private const val USER_ID_CLAIM = "userId"
-        private const val REQ_ATTR_USER_ID = "userId"
-        private const val HDR_AUTHORIZATION = "Authorization"
-        private const val BEARER_PREFIX = "Bearer "
+        private val permitAllMatchers =
+            listOf(
+                AntPathRequestMatcher("/community/boards", HttpMethod.GET.name()),
+                AntPathRequestMatcher("/community/boards/{board_id}", HttpMethod.GET.name()),
+                AntPathRequestMatcher("/community/**/web"),
+                AntPathRequestMatcher("/menus/**/web"),
+                AntPathRequestMatcher("/reviews/**/web"),
+                AntPathRequestMatcher("/v2/**/web"),
+                AntPathRequestMatcher("/error"),
+                AntPathRequestMatcher("/swagger-ui/**"),
+                AntPathRequestMatcher("/v3/api-docs/**"),
+                AntPathRequestMatcher("/docs"),
+                AntPathRequestMatcher("/actuator/health"),
+                AntPathRequestMatcher("/restaurants"),
+                AntPathRequestMatcher("/auth/privacy-policy"),
+                AntPathRequestMatcher("/auth/login/**"),
+                AntPathRequestMatcher("/auth/nicknames/validate"),
+                AntPathRequestMatcher("/reviews/comments/recommendation"),
+                AntPathRequestMatcher("/reviews/dist"),
+                AntPathRequestMatcher("/reviews/keyword/dist"),
+                AntPathRequestMatcher("/v2/reviews/dist"),
+                AntPathRequestMatcher("/v2/reviews/keyword/dist"),
+                AntPathRequestMatcher("/voc"),
+                AntPathRequestMatcher("/ping"),
+                AntPathRequestMatcher("/versions/**", HttpMethod.GET.name()),
+                AntPathRequestMatcher("/menus/festival/**"),
+            )
     }
 
-    private val permitAllMatchers =
-        listOf(
-            AntPathRequestMatcher("/community/boards", HttpMethod.GET.name()),
-            AntPathRequestMatcher("/community/boards/{board_id}", HttpMethod.GET.name()),
-            AntPathRequestMatcher("/community/**/web"),
-            AntPathRequestMatcher("/menus/**/web"),
-            AntPathRequestMatcher("/reviews/**/web"),
-            AntPathRequestMatcher("/v2/**/web"),
-            AntPathRequestMatcher("/error"),
-            AntPathRequestMatcher("/swagger-ui/**"),
-            AntPathRequestMatcher("/v3/api-docs/**"),
-            AntPathRequestMatcher("/docs"),
-            AntPathRequestMatcher("/actuator/health"),
-            AntPathRequestMatcher("/restaurants"),
-            AntPathRequestMatcher("/auth/privacy-policy"),
-            AntPathRequestMatcher("/auth/login/**"),
-            AntPathRequestMatcher("/auth/nicknames/validate"),
-            AntPathRequestMatcher("/reviews/comments/recommendation"),
-            AntPathRequestMatcher("/reviews/dist"),
-            AntPathRequestMatcher("/reviews/keyword/dist"),
-            AntPathRequestMatcher("/v2/reviews/dist"),
-            AntPathRequestMatcher("/v2/reviews/keyword/dist"),
-            AntPathRequestMatcher("/voc"),
-            AntPathRequestMatcher("/ping"),
-            AntPathRequestMatcher("/v2/crawler/**"),
-            AntPathRequestMatcher("/versions/**", HttpMethod.GET.name()),
-            AntPathRequestMatcher("/versions/**", HttpMethod.PATCH.name()),
-            AntPathRequestMatcher("/menus/festival/**"),
-        )
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+        request.method.equals(HttpMethod.OPTIONS.name(), ignoreCase = true) ||
+            permitAllMatchers.any { it.matches(request) } ||
+            CrawlerApiKeyFilter.requiresApiKey(request)
 
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         chain: FilterChain,
     ) {
-        // CORS preflight 요청은 무조건 통과
-        if (request.method.equals(HttpMethod.OPTIONS.name(), ignoreCase = true)) {
-            chain.doFilter(request, response)
-            return
-        }
-
-        // permitAll 경로는 인증 없이 통과
-        if (permitAllMatchers.any { it.matches(request) }) {
-            chain.doFilter(request, response)
-            return
-        }
-
-        // Bearer 토큰 추출
         val token = extractBearerToken(request)
         if (token == null) {
             unauthorized(request, response)
             return
         }
 
-        // 토큰 검증 및 사용자 인증 설정
-        runCatching {
-            val userId = verifyAndExtractUserId(token)
-            setAuthenticatedUser(userId, request)
-        }.onFailure {
-            unauthorized(request, response)
-            return
-        }
+        val userId =
+            runCatching { verifyAndExtractUserId(token) }
+                .getOrElse {
+                    unauthorized(request, response)
+                    return
+                }
 
+        request.setAttribute(USER_ID, userId)
         chain.doFilter(request, response)
     }
 
     private fun extractBearerToken(request: HttpServletRequest): String? =
         request
-            .getHeader(HDR_AUTHORIZATION)
+            .getHeader(AUTHORIZATION)
             ?.takeIf { it.startsWith(BEARER_PREFIX, ignoreCase = true) }
             ?.substring(BEARER_PREFIX.length)
             ?.trim()
@@ -103,13 +88,13 @@ class JwtAuthenticationFilter(
 
     private fun verifyAndExtractUserId(token: String): Int {
         val claims = jwtProvider.verifyJwtGetClaims(token)
-        val value = claims[USER_ID_CLAIM] ?: error("no userId claim")
+        val value = claims[USER_ID] ?: throw UnauthorizedUserException()
         return when (value) {
             is Int -> value
             is Long -> value.toInt()
             is Number -> value.toInt()
-            is String -> value.toIntOrNull() ?: error("bad userId")
-            else -> error("bad userId type")
+            is String -> value.toIntOrNull() ?: throw UnauthorizedUserException()
+            else -> throw UnauthorizedUserException()
         }
     }
 
@@ -119,18 +104,8 @@ class JwtAuthenticationFilter(
     ) {
         resolver.resolveException(request, response, null, UnauthorizedUserException())
     }
-
-    private fun setAuthenticatedUser(
-        userId: Int,
-        request: HttpServletRequest,
-    ) {
-        val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
-        val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
-        SecurityContextHolder.getContext().authentication = authentication
-        request.setAttribute(REQ_ATTR_USER_ID, userId)
-    }
 }
 
 /** 컨트롤러/서비스 단에서 userId 꺼낼 때 사용하는 확장 프로퍼티 */
 val HttpServletRequest.userId: Int
-    get() = (getAttribute("userId") as? Int) ?: throw UnauthorizedUserException()
+    get() = (getAttribute(USER_ID) as? Int) ?: throw UnauthorizedUserException()

--- a/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
+++ b/api/src/main/kotlin/siksha/wafflestudio/api/common/SecurityConfig.kt
@@ -1,31 +1,21 @@
 package siksha.wafflestudio.api.common
 
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
-import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
-import org.springframework.web.servlet.HandlerExceptionResolver
-import siksha.wafflestudio.core.domain.common.exception.auth.UnauthorizedUserException
-
-private typealias AuthorizationRegistry = AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val crawlerApiKeyFilter: CrawlerApiKeyFilter,
-    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
@@ -35,62 +25,10 @@ class SecurityConfig(
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { configureAuthorization(it) }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(crawlerApiKeyFilter, JwtAuthenticationFilter::class.java)
-            .exceptionHandling { configureExceptionHandling(it) }
             .build()
-
-    private fun configureAuthorization(auth: AuthorizationRegistry) {
-        auth
-            .requestMatchers(HttpMethod.OPTIONS, "/**")
-            .permitAll()
-            .requestMatchers(
-                HttpMethod.GET,
-                "/community/boards",
-                "/community/boards/{board_id}",
-                "/versions/**",
-            ).permitAll()
-            .requestMatchers(HttpMethod.PATCH, "/versions/**")
-            .permitAll()
-            .requestMatchers(
-                AntPathRequestMatcher.antMatcher("/community/**/web"),
-                AntPathRequestMatcher.antMatcher("/menus/**/web"),
-                AntPathRequestMatcher.antMatcher("/reviews/**/web"),
-                AntPathRequestMatcher.antMatcher("/v2/**/web"),
-            ).permitAll()
-            .requestMatchers(
-                "/error",
-                "/swagger-ui/**",
-                "/v3/api-docs/**",
-                "/actuator/health",
-                "/restaurants",
-                "/auth/privacy-policy",
-                "/auth/login/**",
-                "/auth/nicknames/validate",
-                "/docs",
-                "/reviews/comments/recommendation",
-                "/reviews/dist",
-                "/reviews/keyword/dist",
-                "/v2/reviews/dist",
-                "/v2/reviews/keyword/dist",
-                "/voc",
-                "/ping",
-                "/v2/crawler/**",
-                "/menus/festival/**",
-            ).permitAll()
-            .anyRequest()
-            .authenticated()
-    }
-
-    private fun configureExceptionHandling(handler: ExceptionHandlingConfigurer<HttpSecurity>) {
-        handler
-            .authenticationEntryPoint { request, response, _ ->
-                resolver.resolveException(request, response, null, UnauthorizedUserException())
-            }.accessDeniedHandler { request, response, _ ->
-                resolver.resolveException(request, response, null, UnauthorizedUserException())
-            }
-    }
 
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource =

--- a/api/src/test/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilterTest.kt
+++ b/api/src/test/kotlin/siksha/wafflestudio/api/common/CrawlerApiKeyFilterTest.kt
@@ -4,6 +4,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.FilterChain
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.web.servlet.HandlerExceptionResolver
@@ -12,9 +15,13 @@ class CrawlerApiKeyFilterTest {
     private val resolver = mockk<HandlerExceptionResolver>(relaxed = true)
     private val filter = CrawlerApiKeyFilter("crawler-key", resolver)
 
-    @Test
-    fun `reject version update without crawler api key`() {
-        val request = MockHttpServletRequest("PATCH", "/versions/IOS")
+    @ParameterizedTest
+    @MethodSource("crawlerAuthenticatedRequests")
+    fun `reject crawler authenticated request without api key`(
+        method: String,
+        path: String,
+    ) {
+        val request = MockHttpServletRequest(method, path)
         val response = MockHttpServletResponse()
         val chain = mockk<FilterChain>(relaxed = true)
 
@@ -24,10 +31,14 @@ class CrawlerApiKeyFilterTest {
         verify(exactly = 0) { chain.doFilter(any(), any()) }
     }
 
-    @Test
-    fun `allow version update with crawler api key`() {
+    @ParameterizedTest
+    @MethodSource("crawlerAuthenticatedRequests")
+    fun `allow crawler authenticated request with api key`(
+        method: String,
+        path: String,
+    ) {
         val request =
-            MockHttpServletRequest("PATCH", "/versions/IOS").apply {
+            MockHttpServletRequest(method, path).apply {
                 addHeader("X-API-Key", "crawler-key")
             }
         val response = MockHttpServletResponse()
@@ -49,5 +60,29 @@ class CrawlerApiKeyFilterTest {
 
         verify(exactly = 0) { resolver.resolveException(any(), any(), any(), any()) }
         verify(exactly = 1) { chain.doFilter(request, response) }
+    }
+
+    @Test
+    fun `reject crawler authenticated request with invalid api key`() {
+        val request =
+            MockHttpServletRequest("POST", "/v2/crawler/meals").apply {
+                addHeader("X-API-Key", "invalid-key")
+            }
+        val response = MockHttpServletResponse()
+        val chain = mockk<FilterChain>(relaxed = true)
+
+        filter.doFilter(request, response, chain)
+
+        verify(exactly = 1) { resolver.resolveException(request, response, null, any()) }
+        verify(exactly = 0) { chain.doFilter(any(), any()) }
+    }
+
+    companion object {
+        @JvmStatic
+        fun crawlerAuthenticatedRequests(): List<Arguments> =
+            listOf(
+                Arguments.of("POST", "/v2/crawler/meals"),
+                Arguments.of("PATCH", "/versions/IOS"),
+            )
     }
 }

--- a/api/src/test/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/siksha/wafflestudio/api/common/JwtAuthenticationFilterTest.kt
@@ -1,25 +1,40 @@
 package siksha.wafflestudio.api.common
 
+import io.jsonwebtoken.Claims
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.servlet.HandlerExceptionResolver
 import siksha.wafflestudio.core.domain.auth.JwtProvider
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class JwtAuthenticationFilterTest {
-    private val jwtProvider = mockk<JwtProvider>(relaxed = true)
+    private val jwtProvider = mockk<JwtProvider>()
     private val resolver = mockk<HandlerExceptionResolver>(relaxed = true)
     private val filter = JwtAuthenticationFilter(jwtProvider, resolver)
 
-    @Test
-    fun `allow version lookup without jwt`() {
-        val request =
-            MockHttpServletRequest("GET", "/versions/IOS").apply {
-                servletPath = "/versions/IOS"
-            }
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @ParameterizedTest
+    @MethodSource("publicRequests")
+    fun `allow current public request without jwt`(
+        method: String,
+        path: String,
+    ) {
+        val request = request(method, path)
         val response = MockHttpServletResponse()
         val chain = mockk<FilterChain>(relaxed = true)
 
@@ -29,12 +44,13 @@ class JwtAuthenticationFilterTest {
         verify(exactly = 1) { chain.doFilter(request, response) }
     }
 
-    @Test
-    fun `allow version update without jwt because api key filter owns update authentication`() {
-        val request =
-            MockHttpServletRequest("PATCH", "/versions/IOS").apply {
-                servletPath = "/versions/IOS"
-            }
+    @ParameterizedTest
+    @MethodSource("crawlerAuthenticatedRequests")
+    fun `allow crawler key owned request to bypass jwt`(
+        method: String,
+        path: String,
+    ) {
+        val request = request(method, path)
         val response = MockHttpServletResponse()
         val chain = mockk<FilterChain>(relaxed = true)
 
@@ -44,11 +60,47 @@ class JwtAuthenticationFilterTest {
         verify(exactly = 1) { chain.doFilter(request, response) }
     }
 
+    @ParameterizedTest
+    @MethodSource("protectedRequests")
+    fun `reject protected request without jwt`(
+        method: String,
+        path: String,
+    ) {
+        val request = request(method, path)
+        val response = MockHttpServletResponse()
+        val chain = mockk<FilterChain>(relaxed = true)
+
+        filter.doFilter(request, response, chain)
+
+        verify(exactly = 1) { resolver.resolveException(request, response, null, any()) }
+        verify(exactly = 0) { chain.doFilter(any(), any()) }
+    }
+
     @Test
-    fun `reject unsupported version method without jwt`() {
+    fun `expose authenticated user id without populating spring security context`() {
+        val claims = mockk<Claims>()
+        every { claims["userId"] } returns 42
+        every { jwtProvider.verifyJwtGetClaims("valid-token") } returns claims
         val request =
-            MockHttpServletRequest("DELETE", "/versions/IOS").apply {
-                servletPath = "/versions/IOS"
+            request("GET", "/auth/me").apply {
+                addHeader("Authorization", "Bearer valid-token")
+            }
+        val response = MockHttpServletResponse()
+        val chain = mockk<FilterChain>(relaxed = true)
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals(42, request.getAttribute("userId"))
+        assertNull(SecurityContextHolder.getContext().authentication)
+        verify(exactly = 1) { chain.doFilter(request, response) }
+    }
+
+    @Test
+    fun `reject invalid jwt`() {
+        every { jwtProvider.verifyJwtGetClaims("invalid-token") } throws IllegalArgumentException("invalid jwt")
+        val request =
+            request("GET", "/auth/me").apply {
+                addHeader("Authorization", "Bearer invalid-token")
             }
         val response = MockHttpServletResponse()
         val chain = mockk<FilterChain>(relaxed = true)
@@ -57,5 +109,62 @@ class JwtAuthenticationFilterTest {
 
         verify(exactly = 1) { resolver.resolveException(request, response, null, any()) }
         verify(exactly = 0) { chain.doFilter(any(), any()) }
+    }
+
+    private fun request(
+        method: String,
+        path: String,
+    ): MockHttpServletRequest =
+        MockHttpServletRequest(method, path).apply {
+            servletPath = path
+        }
+
+    companion object {
+        @JvmStatic
+        fun publicRequests(): List<Arguments> =
+            listOf(
+                Arguments.of("OPTIONS", "/auth/me"),
+                Arguments.of("GET", "/community/boards"),
+                Arguments.of("GET", "/community/boards/1"),
+                Arguments.of("GET", "/community/posts/web"),
+                Arguments.of("GET", "/menus/1/web"),
+                Arguments.of("GET", "/reviews/1/web"),
+                Arguments.of("GET", "/v2/menus/web"),
+                Arguments.of("GET", "/error"),
+                Arguments.of("GET", "/swagger-ui/index.html"),
+                Arguments.of("GET", "/v3/api-docs/siksha"),
+                Arguments.of("GET", "/docs"),
+                Arguments.of("GET", "/actuator/health"),
+                Arguments.of("GET", "/restaurants"),
+                Arguments.of("GET", "/auth/privacy-policy"),
+                Arguments.of("POST", "/auth/login/apple"),
+                Arguments.of("GET", "/auth/nicknames/validate"),
+                Arguments.of("GET", "/reviews/comments/recommendation"),
+                Arguments.of("GET", "/reviews/dist"),
+                Arguments.of("GET", "/reviews/keyword/dist"),
+                Arguments.of("GET", "/v2/reviews/dist"),
+                Arguments.of("GET", "/v2/reviews/keyword/dist"),
+                Arguments.of("POST", "/voc"),
+                Arguments.of("GET", "/ping"),
+                Arguments.of("GET", "/versions/IOS"),
+                Arguments.of("GET", "/menus/festival/dates"),
+            )
+
+        @JvmStatic
+        fun crawlerAuthenticatedRequests(): List<Arguments> =
+            listOf(
+                Arguments.of("POST", "/v2/crawler/meals"),
+                Arguments.of("PATCH", "/versions/IOS"),
+            )
+
+        @JvmStatic
+        fun protectedRequests(): List<Arguments> =
+            listOf(
+                Arguments.of("GET", "/auth/me"),
+                Arguments.of("POST", "/community/boards"),
+                Arguments.of("GET", "/menus"),
+                Arguments.of("GET", "/v2/restaurants/personal"),
+                Arguments.of("DELETE", "/versions/IOS"),
+            )
     }
 }

--- a/api/src/test/kotlin/siksha/wafflestudio/api/common/SecurityConfigTest.kt
+++ b/api/src/test/kotlin/siksha/wafflestudio/api/common/SecurityConfigTest.kt
@@ -1,0 +1,85 @@
+package siksha.wafflestudio.api.common
+
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.web.FilterChainProxy
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.web.filter.CorsFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+import siksha.wafflestudio.core.domain.auth.JwtProvider
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringJUnitConfig(classes = [SecurityConfig::class, SecurityConfigTest.TestConfig::class])
+@WebAppConfiguration
+class SecurityConfigTest(
+    @param:Autowired private val filterChainProxy: FilterChainProxy,
+    @param:Autowired @param:Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
+) {
+    @Test
+    fun `cors filter runs before custom authentication filters`() {
+        val filters = filterChainProxy.filterChains.single().filters
+        val corsFilterIndex = filters.indexOfFirst { it is CorsFilter }
+        val crawlerApiKeyFilterIndex = filters.indexOfFirst { it is CrawlerApiKeyFilter }
+        val jwtAuthenticationFilterIndex = filters.indexOfFirst { it is JwtAuthenticationFilter }
+
+        assertTrue(corsFilterIndex >= 0)
+        assertTrue(crawlerApiKeyFilterIndex >= 0)
+        assertTrue(jwtAuthenticationFilterIndex >= 0)
+        assertTrue(corsFilterIndex < crawlerApiKeyFilterIndex)
+        assertTrue(corsFilterIndex < jwtAuthenticationFilterIndex)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["/auth/me", "/v2/crawler/meals"])
+    fun `allow cors preflight before authentication filters`(path: String) {
+        val origin = "https://siksha.example.com"
+        val request =
+            MockHttpServletRequest("OPTIONS", path).apply {
+                servletPath = path
+                addHeader(HttpHeaders.ORIGIN, origin)
+                addHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")
+            }
+        val response = MockHttpServletResponse()
+        val downstreamChain = mockk<FilterChain>(relaxed = true)
+
+        filterChainProxy.doFilter(request, response, downstreamChain)
+
+        assertEquals(200, response.status)
+        assertEquals(origin, response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+        verify(exactly = 0) { resolver.resolveException(any(), any(), any(), any()) }
+        verify(exactly = 0) { downstreamChain.doFilter(any(), any()) }
+    }
+
+    @Configuration
+    class TestConfig {
+        @Bean
+        fun jwtAuthenticationFilter(
+            jwtProvider: JwtProvider,
+            @Qualifier("handlerExceptionResolver") resolver: HandlerExceptionResolver,
+        ) = JwtAuthenticationFilter(jwtProvider, resolver)
+
+        @Bean
+        fun crawlerApiKeyFilter(
+            @Qualifier("handlerExceptionResolver") resolver: HandlerExceptionResolver,
+        ) = CrawlerApiKeyFilter("crawler-key", resolver)
+
+        @Bean
+        fun jwtProvider(): JwtProvider = mockk()
+
+        @Bean("handlerExceptionResolver")
+        fun handlerExceptionResolver(): HandlerExceptionResolver = mockk(relaxed = true)
+    }
+}


### PR DESCRIPTION
## 변경 사항
- PR #98의 방향을 참고해 `SecurityConfig`의 중복 인가 선언을 제거하고, 실제 인증 경계를 커스텀 필터로 일원화했습니다.
- 현재 main의 permit API와 crawler key 인증 API 목록은 그대로 유지했습니다.
- crawler key 대상 판별을 `CrawlerApiKeyFilter.requiresApiKey`로 통합해 JWT 필터와의 중복 선언을 제거했습니다.
- 사용되지 않던 Spring Security 인증 객체 구성을 제거하고 request attribute의 `userId`만 유지했습니다.
- 상수 이름과 위치를 정리했습니다.

## 검증
- `./gradlew --no-daemon --console=plain --rerun-tasks :api:ktlintCheck :api:test :api:bootJar`
- 공개 API, crawler key API, 보호 API, 유효/무효 JWT와 API key 경계를 테스트로 추가했습니다.
- 실제 `SecurityFilterChain`에서 `CorsFilter`가 커스텀 인증 필터보다 먼저 실행되고, 보호 API와 crawler API의 CORS preflight가 인증 없이 처리되는 것을 검증했습니다.

참고: #98